### PR TITLE
Do not show resource linking if template found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.3.0
+
+* `FEAT`: add `resourceLinking.linkResource` rule ([#47](https://github.com/camunda/improved-canvas/pull/47))
+* `FIX`: do not show resource linking if element template found ([#47](https://github.com/camunda/improved-canvas/pull/47))
+
 ## 1.2.4
 
 * `FIX`: ensure icons are visible in all major browsers ([#42](https://github.com/camunda/improved-canvas/pull/42))

--- a/lib/bpmn/resourceLinking/ResourceLinkingContextPadProvider.js
+++ b/lib/bpmn/resourceLinking/ResourceLinkingContextPadProvider.js
@@ -2,7 +2,8 @@ import { isLabel } from 'diagram-js/lib/util/ModelUtil';
 
 import {
   getBusinessObject,
-  is
+  is,
+  isAny
 } from 'bpmn-js/lib/util/ModelUtil';
 
 import { isString } from 'min-dash';
@@ -21,6 +22,7 @@ const LOW_PRIORITY = 200;
  *
  * @type {import('diagram-js/lib/features/context-pad/ContextPad').default} ContextPad
  * @type {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @type {import('diagram-js/lib/features/rules/Rules').default} Rules
  */
 
 /**
@@ -37,11 +39,13 @@ const LOW_PRIORITY = 200;
  * @param {Config} config
  * @param {ContextPad} contextPad
  * @param {EventBus} eventBus
+ * @param {Rules} rules
  **/
-export default function ResourceLinking(config, contextPad, eventBus) {
+export default function ResourceLinking(config, contextPad, eventBus, rules) {
   this._config = config;
   this._eventBus = eventBus;
   this._contextPad = contextPad;
+  this._rules = rules;
 
   contextPad.registerProvider(LOW_PRIORITY, this);
 }
@@ -49,14 +53,15 @@ export default function ResourceLinking(config, contextPad, eventBus) {
 ResourceLinking.$inject = [
   'config.resourceLinking',
   'contextPad',
-  'eventBus'
+  'eventBus',
+  'rules'
 ];
 
 ResourceLinking.prototype.getContextPadEntries = function(target) {
   const self = this;
 
   return (entries) => {
-    if (isLabel(target)) {
+    if (isLabel(target) || ! this._canLinkResource(target)) {
       return entries;
     }
 
@@ -69,7 +74,7 @@ ResourceLinking.prototype.getContextPadEntries = function(target) {
     } else if (is(target, 'bpmn:CallActivity')) {
       resourceType = 'process';
       hasResource = hasCalledProcess(target);
-    } else if (is(target, 'bpmn:UserTask') || (isNoneStartEventSupported(this._config) && isNoneStartEvent(target))) {
+    } else if (isAny(target, [ 'bpmn:StartEvent', 'bpmn:UserTask' ])) {
       resourceType = 'form';
       hasResource = hasFormIdOrKey(target);
     }
@@ -92,6 +97,10 @@ ResourceLinking.prototype.getContextPadEntries = function(target) {
     };
 
   };
+};
+
+ResourceLinking.prototype._canLinkResource = function(element) {
+  return this._rules.allowed('resourceLinking.linkResource', { element });
 };
 
 
@@ -161,23 +170,4 @@ function hasCalledProcess(element) {
   const processId = calledProcess.get('processId');
 
   return isString(processId) && processId.trim().length;
-}
-
-function isNoneStartEvent(element) {
-  const eventDefinitions = getBusinessObject(element).get('eventDefinitions');
-
-  return is(element, 'bpmn:StartEvent') && (!eventDefinitions || !eventDefinitions.length);
-}
-
-/**
- * Check whether the none start event is supported.
- *
- * @param {Config|undefined} config
- *
- * @returns {boolean}
- */
-function isNoneStartEventSupported(config = {}) {
-  const { noneStartEvent = true } = config;
-
-  return noneStartEvent;
 }

--- a/lib/bpmn/resourceLinking/ResourceLinkingRules.js
+++ b/lib/bpmn/resourceLinking/ResourceLinkingRules.js
@@ -1,0 +1,38 @@
+import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
+
+import {
+  getBusinessObject,
+  is,
+  isAny
+} from 'bpmn-js/lib/util/ModelUtil';
+
+export default class ResourceLinkingRules extends RuleProvider {
+  constructor(config, eventBus) {
+    super(eventBus);
+
+    this.addRule('resourceLinking.linkResource', ({ element }) => {
+      return isAny(element, [ 'bpmn:BusinessRuleTask', 'bpmn:CallActivity', 'bpmn:UserTask' ]) || (isNoneStartEvent(element) && isNoneStartEventSupported(config));
+    });
+  }
+}
+
+ResourceLinkingRules.$inject = [ 'config.resourceLinking', 'eventBus' ];
+
+function isNoneStartEvent(element) {
+  const eventDefinitions = getBusinessObject(element).get('eventDefinitions');
+
+  return is(element, 'bpmn:StartEvent') && (!eventDefinitions || !eventDefinitions.length);
+}
+
+/**
+ * Check whether the none start event is supported.
+ *
+ * @param {Config|undefined} config
+ *
+ * @returns {boolean}
+ */
+function isNoneStartEventSupported(config = {}) {
+  const { noneStartEvent = true } = config;
+
+  return noneStartEvent;
+}

--- a/lib/bpmn/resourceLinking/ResourceLinkingRules.js
+++ b/lib/bpmn/resourceLinking/ResourceLinkingRules.js
@@ -11,12 +11,18 @@ export default class ResourceLinkingRules extends RuleProvider {
     super(eventBus);
 
     this.addRule('resourceLinking.linkResource', ({ element }) => {
-      return isAny(element, [ 'bpmn:BusinessRuleTask', 'bpmn:CallActivity', 'bpmn:UserTask' ]) || (isNoneStartEvent(element) && isNoneStartEventSupported(config));
+      return !hasElementTemplate(element) && (
+        isAny(element, [ 'bpmn:BusinessRuleTask', 'bpmn:CallActivity', 'bpmn:UserTask' ]) || (isNoneStartEvent(element) && isNoneStartEventSupported(config))
+      );
     });
   }
 }
 
 ResourceLinkingRules.$inject = [ 'config.resourceLinking', 'eventBus' ];
+
+function hasElementTemplate(element) {
+  return getBusinessObject(element).get('zeebe:modelerTemplate');
+}
 
 function isNoneStartEvent(element) {
   const eventDefinitions = getBusinessObject(element).get('eventDefinitions');

--- a/lib/bpmn/resourceLinking/index.js
+++ b/lib/bpmn/resourceLinking/index.js
@@ -1,6 +1,8 @@
-import ResourceLinking from './ResourceLinkingContextPadProvider';
+import ResourceLinkingContextPadProvider from './ResourceLinkingContextPadProvider';
+import ResourceLinkingRules from './ResourceLinkingRules';
 
 export default {
-  __init__: [ 'resourceLinking' ],
-  resourceLinking: [ 'type', ResourceLinking ]
+  __init__: [ 'resourceLinkingContextPadProvider', 'resourceLinkingRules' ],
+  resourceLinkingContextPadProvider: [ 'type', ResourceLinkingContextPadProvider ],
+  resourceLinkingRules: [ 'type', ResourceLinkingRules ]
 };

--- a/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
+++ b/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
@@ -12,7 +12,12 @@ import {
 
 import { waitFor } from '@testing-library/preact';
 
-import { getBusinessObject } from 'bpmn-js/lib/util/ModelUtil';
+import {
+  getBusinessObject,
+  is
+} from 'bpmn-js/lib/util/ModelUtil';
+
+import CustomRulesModule from 'bpmn-js/test/util/custom-rules';
 
 import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
@@ -29,7 +34,8 @@ describe('<ResourceLinking>', function() {
   beforeEach(bootstrapModeler(diagramXML, {
     additionalModules: [
       ImprovedContextPad,
-      ResourceLinking
+      ResourceLinking,
+      CustomRulesModule
     ],
     moddleExtensions: {
       zeebe: ZeebeModdle
@@ -551,6 +557,40 @@ describe('<ResourceLinking>', function() {
         element: task,
         originalEvent: event
       });
+    }));
+
+  });
+
+
+  describe('rules', function() {
+
+    it('should allow by default', inject(function(elementRegistry, contextPad) {
+
+      // given
+      const task = elementRegistry.get('UserTask');
+
+      // when
+      contextPad.open(task);
+
+      // then
+      expect(domQuery('.entry[data-action="link-resource"]')).to.exist;
+    }));
+
+
+    it('should disallow', inject(function(elementRegistry, contextPad, customRules) {
+
+      // given
+      customRules.addRule('resourceLinking.linkResource', 2000, ({ element }) => {
+        return !is(element, 'bpmn:UserTask');
+      });
+
+      const task = elementRegistry.get('UserTask');
+
+      // when
+      contextPad.open(task);
+
+      // then
+      expect(domQuery('.entry[data-action="link-resource"]')).not.to.exist;
     }));
 
   });

--- a/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
+++ b/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
@@ -593,6 +593,23 @@ describe('<ResourceLinking>', function() {
       expect(domQuery('.entry[data-action="link-resource"]')).not.to.exist;
     }));
 
+
+    it('should disallow if element template found', inject(function(elementRegistry, contextPad, modeling) {
+
+      // given
+      const task = elementRegistry.get('UserTask');
+
+      modeling.updateProperties(task, {
+        'zeebe:modelerTemplate': 'foo'
+      });
+
+      // when
+      contextPad.open(task);
+
+      // then
+      expect(domQuery('.entry[data-action="link-resource"]')).not.to.exist;
+    }));
+
   });
 
 });


### PR DESCRIPTION
* introduces rule to show resource linking (can be overridden)
* doesn't show resource linking if element template found (default behavior, can be overridden)

Related to https://github.com/camunda/web-modeler/issues/8523