### PR TITLE
fix(a11y): use `role` instead of `aria-role`

### DIFF
--- a/lib/common/contextPad/ImprovedContextPad.js
+++ b/lib/common/contextPad/ImprovedContextPad.js
@@ -61,7 +61,7 @@ ImprovedContextPad.prototype._renderTooltips = function({ current }) {
     const title = entry.getAttribute('title');
     entry.removeAttribute('title');
     entry.setAttribute('aria-label', title);
-    entry.setAttribute('aria-role', 'button');
+    entry.setAttribute('role', 'button');
 
     // render entry with tooltip
     const placeholderContainer = domify('<div></div>');


### PR DESCRIPTION
`aria-role` doesn't exist. `role` is the one I was aiming for.

Closes #43 (again 🤡)