### PR TITLE
chore(contextPad): clean up event listeners

### DIFF
--- a/lib/bpmn/contextPad/ImprovedContextPadProvider.js
+++ b/lib/bpmn/contextPad/ImprovedContextPadProvider.js
@@ -181,7 +181,7 @@ function updateAction(eventBus, entries, id, action) {
     const entry = getEntry(entries, id);
     entry.classList.add('active');
 
-    eventBus.on('popupMenu.close', function() {
+    eventBus.once('popupMenu.close', function() {
       entry.classList.remove('active');
     });
   };

--- a/lib/common/contextPad/ImprovedContextPadProvider.js
+++ b/lib/common/contextPad/ImprovedContextPadProvider.js
@@ -110,7 +110,7 @@ function updateAction(eventBus, entries, id, action) {
     const entry = getEntry(entries, id);
     entry.classList.add('active');
 
-    eventBus.on('popupMenu.close', function() {
+    eventBus.once('popupMenu.close', function() {
       entry.classList.remove('active');
     });
   };


### PR DESCRIPTION
This ensures we clean up registered event listeners for 'active' handling once the menu was closed. A new one will be registered when the menu is opened again.