### PR TITLE
fix(resource-linking): disallow if start event parent not process

### DIFF
--- a/lib/bpmn/resourceLinking/ResourceLinkingRules.js
+++ b/lib/bpmn/resourceLinking/ResourceLinkingRules.js
@@ -23,7 +23,7 @@ export default class ResourceLinkingRules extends RuleProvider {
         return true;
       }
 
-      if (isNoneStartEvent(element) && isNoneStartEventSupported(config) && !isEventSubProcess(element.parent)) {
+      if (isNoneStartEvent(element) && isNoneStartEventSupported(config) && !is(element.parent, 'bpmn:SubProcess')) {
         return true;
       }
 
@@ -55,8 +55,4 @@ function isNoneStartEventSupported(config = {}) {
   const { noneStartEvent = true } = config;
 
   return noneStartEvent;
-}
-
-function isEventSubProcess(element) {
-  return getBusinessObject(element).get('triggeredByEvent');
 }

--- a/test/spec/bpmn/resourceLinking/ResourceLinking.bpmn
+++ b/test/spec/bpmn/resourceLinking/ResourceLinking.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_043jtgn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_043jtgn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
   <bpmn:process id="Process_1i8nbae" isExecutable="true">
     <bpmn:extensionElements>
       <zeebe:userTaskForm id="UserTaskForm_1">{"id": "Form_1"}</zeebe:userTaskForm>
@@ -51,6 +51,9 @@
     </bpmn:userTask>
     <bpmn:subProcess id="EventSubprocess" name="EventSubprocess" triggeredByEvent="true">
       <bpmn:startEvent id="EventSubprocessStartEvent" name="EventSubprocessStartEvent" />
+    </bpmn:subProcess>
+    <bpmn:subProcess id="Subprocess" name="Subprocess">
+      <bpmn:startEvent id="SubprocessStartEvent" name="SubprocessStartEvent" />
     </bpmn:subProcess>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
@@ -113,6 +116,16 @@
         <dc:Bounds x="540" y="162" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="515" y="205" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06evoym_di" bpmnElement="Subprocess" isExpanded="true">
+        <dc:Bounds x="870" y="80" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hot6z8_di" bpmnElement="SubprocessStartEvent">
+        <dc:Bounds x="910" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="887" y="205" width="82" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
+++ b/test/spec/bpmn/resourceLinking/ResourceLinking.spec.js
@@ -25,6 +25,7 @@ import ImprovedContextPad from 'lib/bpmn/contextPad';
 import ResourceLinking from 'lib/bpmn/resourceLinking';
 
 import diagramXML from './ResourceLinking.bpmn';
+import diagramCollaborationXML from './ResourceLinkingCollaboration.bpmn';
 
 insertCoreStyles();
 insertBpmnStyles();
@@ -613,6 +614,19 @@ describe('<ResourceLinking>', function() {
     }));
 
 
+    it('should disallow if none start event in subprocess', inject(function(elementRegistry, contextPad, modeling) {
+
+      // given
+      const startEvent = elementRegistry.get('SubprocessStartEvent');
+
+      // when
+      contextPad.open(startEvent);
+
+      // then
+      expect(domQuery('.entry[data-action="link-resource"]')).not.to.exist;
+    }));
+
+
     it('should disallow if none start event in event subprocess', inject(function(elementRegistry, contextPad, modeling) {
 
       // given
@@ -624,6 +638,52 @@ describe('<ResourceLinking>', function() {
       // then
       expect(domQuery('.entry[data-action="link-resource"]')).not.to.exist;
     }));
+
+
+    describe('process', function() {
+
+      it('should allow if none start event in process', inject(function(elementRegistry, contextPad, modeling) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent');
+
+        // when
+        contextPad.open(startEvent);
+
+        // then
+        expect(domQuery('.entry[data-action="link-resource"]')).to.exist;
+      }));
+
+    });
+
+
+    describe('collaboration', function() {
+
+      beforeEach(bootstrapModeler(diagramCollaborationXML, {
+        additionalModules: [
+          ImprovedContextPad,
+          ResourceLinking,
+          CustomRulesModule
+        ],
+        moddleExtensions: {
+          zeebe: ZeebeModdle
+        },
+      }));
+
+
+      it('should allow if none start event in participant', inject(function(elementRegistry, contextPad, modeling) {
+
+        // given
+        const startEvent = elementRegistry.get('StartEvent');
+
+        // when
+        contextPad.open(startEvent);
+
+        // then
+        expect(domQuery('.entry[data-action="link-resource"]')).to.exist;
+      }));
+
+    });
 
   });
 

--- a/test/spec/bpmn/resourceLinking/ResourceLinkingCollaboration.bpmn
+++ b/test/spec/bpmn/resourceLinking/ResourceLinkingCollaboration.bpmn
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_093dmgc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.26.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0">
+  <bpmn:collaboration id="Collaboration">
+    <bpmn:participant id="Participant" name="Participant" processRef="Process" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent" name="StartEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration">
+      <bpmndi:BPMNShape id="Participant_170f5cm_di" bpmnElement="Participant" isHorizontal="true">
+        <dc:Bounds x="160" y="52" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="229" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="221" y="202" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
Linking a form to a start event is only possible if the parent is a process.

![brave_3X1FrM5adm](https://github.com/user-attachments/assets/175a4e5e-d8fb-45ce-87d2-8747c4056ea8)
