### PR TITLE
chore: support bpmn-js-create-append-anything beyond v0.5.x

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,14 +11,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Setup project
+        uses: bpmn-io/actions/setup@latest
       - name: Build with coverage
         run: COVERAGE=1 npm run all
       - name: Import Secrets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.7.6
+
+* `CHORE`: support bpmn-js-create-append-anything beyond v0.5.x
+
 ## 1.7.5
 
 * `FIX`: disallow linking form to start event if parent is not only participant with executable process ([#76](https://github.com/camunda/improved-canvas/pull/76))

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "babel-plugin-istanbul": "^6.1.1",
         "bpmn-js": "^17.6.4",
         "bpmn-js-color-picker": "^0.7.1",
-        "bpmn-js-create-append-anything": "^0.5.1",
+        "bpmn-js-create-append-anything": "^0.6.0",
         "bpmn-js-element-templates": "^1.15.2",
         "bpmn-js-properties-panel": "^5.15.0",
         "camunda-bpmn-js-behaviors": "^1.3.0",
@@ -59,7 +59,7 @@
         "zeebe-bpmn-moddle": "^1.1.0"
       },
       "peerDependencies": {
-        "bpmn-js-create-append-anything": "^0.5.0"
+        "bpmn-js-create-append-anything": ">=0.5.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2552,10 +2552,11 @@
       }
     },
     "node_modules/bpmn-js-create-append-anything": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-0.5.1.tgz",
-      "integrity": "sha512-WvDCHiDCMd7XZUkAsgVRw2AohOGkXozvn+K4DiDHicuD5vixg1AI+Rz39KnnF9Wp4qpPyEy7zty8gl3uEhbwPg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-0.6.0.tgz",
+      "integrity": "sha512-qSWJ1hUkxiXi+gApCBfm7ixcxQ9LdmcLFIC68rTL/AZxP/Z+7bRmYNw5z1KF61xvdGUV07p4Oia/rpIWyGExqw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@bpmn-io/element-template-chooser": "^1.0.0"
       }
@@ -11348,9 +11349,9 @@
       "requires": {}
     },
     "bpmn-js-create-append-anything": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-0.5.1.tgz",
-      "integrity": "sha512-WvDCHiDCMd7XZUkAsgVRw2AohOGkXozvn+K4DiDHicuD5vixg1AI+Rz39KnnF9Wp4qpPyEy7zty8gl3uEhbwPg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-create-append-anything/-/bpmn-js-create-append-anything-0.6.0.tgz",
+      "integrity": "sha512-qSWJ1hUkxiXi+gApCBfm7ixcxQ9LdmcLFIC68rTL/AZxP/Z+7bRmYNw5z1KF61xvdGUV07p4Oia/rpIWyGExqw==",
       "dev": true,
       "requires": {
         "@bpmn-io/element-template-chooser": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-plugin-istanbul": "^6.1.1",
     "bpmn-js": "^17.6.4",
     "bpmn-js-color-picker": "^0.7.1",
-    "bpmn-js-create-append-anything": "^0.5.1",
+    "bpmn-js-create-append-anything": "^0.6.0",
     "bpmn-js-element-templates": "^1.15.2",
     "bpmn-js-properties-panel": "^5.15.0",
     "camunda-bpmn-js-behaviors": "^1.3.0",
@@ -92,6 +92,6 @@
     "zeebe-bpmn-moddle": "^1.1.0"
   },
   "peerDependencies": {
-    "bpmn-js-create-append-anything": "^0.5.0"
+    "bpmn-js-create-append-anything": ">=0.5.0"
   }
 }


### PR DESCRIPTION
The `^` in semver range before first major version release means that only patch bumps are allowed. This prevented proper update in Web Modeler, cf. https://camunda.slack.com/archives/C0693F1NFK5/p1739527636031429

With this PR, we declare support for any future version of bpmn-js-create-append-anything. In case of a breaking-breaking change, we can re-release with new range.