### PR TITLE
feat: add append indicator(grey `+`) for not completed sequence flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FEAT`: surface unfinished flows with an append indicator that opens the append menu on hover, guiding users to complete the paths ([#83](https://github.com/camunda/improved-canvas/pull/83))
 * `DEPS`: update to `diagram-js-grid@2.0.1`
 
 ## 1.9.1

--- a/assets/create-pad.css
+++ b/assets/create-pad.css
@@ -110,7 +110,7 @@
   width: 28px;
   height: 28px;
   border-radius: 4px;
-  background-color: var(--gray-30);
+  background-color: color-mix(in srgb, var(--gray-30) 80%, transparent);
   color: white;
   cursor: pointer;
 

--- a/assets/create-pad.css
+++ b/assets/create-pad.css
@@ -75,6 +75,7 @@
 /* Append pad: entries always visible as a horizontal row when open */
 .bio-improved-canvas .djs-append-create-pad {
   align-items: center;
+  transform: translate(-20px, -50%);
 
   &.open .djs-create-pad-entries {
     display: flex;
@@ -98,5 +99,27 @@
     &:hover {
       background-color: var(--context-pad-entry-call-to-action-hover-background-color);
     }
+  }
+}
+
+/* always-visible grey "+" indicator nudging the user to complete the path */
+.bio-improved-canvas .djs-append-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 4px;
+  background-color: var(--gray-30);
+  color: white;
+  cursor: pointer;
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    background-color: var(--gray-40);
   }
 }

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -1,13 +1,11 @@
 import { isConnection } from 'diagram-js/lib/util/ModelUtil';
-import { getMid, getOrientation } from 'diagram-js/lib/layout/LayoutUtil';
-import { is } from 'bpmn-js/lib/util/ModelUtil';
 import { omit, pick } from 'min-dash';
 
 import CreatePad from '../../common/createPad/CreatePad';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-import { APPEND_GAP, PAD_CONTENT_OFFSET, CREATE_PAD_MARGIN } from './constants';
+import { APPEND_GAP, PAD_CONTENT_OFFSET } from './constants';
 
 // leading pad entries, in this order; any other entries follow in natural order.
 // connect is relocated here from the context pad.
@@ -100,42 +98,11 @@ export default class AppendCreatePad extends CreatePad {
   }
 
   getPosition(target) {
-    if (is(target, 'bpmn:BoundaryEvent')) {
-      return this._getBoundaryEventPosition(target);
-    }
-
     const { x, y, width, height } = this._canvas.getAbsoluteBBox(target);
 
     return {
       left: x + width + APPEND_GAP * this._canvas.zoom() + PAD_CONTENT_OFFSET,
       top: y + height / 2
-    };
-  }
-
-  _getBoundaryEventPosition(target) {
-    const orientation = getOrientation(getMid(target), target.host);
-
-    const { containerBounds, targetBounds } = this._getRelativeBounds(target);
-
-    const margin = CREATE_PAD_MARGIN * this._canvas.zoom();
-
-    if (orientation.includes('right') || orientation.includes('top') || orientation.includes('left')) {
-      return {
-        left: targetBounds.right + margin - containerBounds.left,
-        top: targetBounds.top + targetBounds.height / 2 - containerBounds.top
-      };
-    }
-
-    return {
-      left: targetBounds.left + targetBounds.width / 2 - containerBounds.left,
-      top: targetBounds.bottom + margin - containerBounds.top
-    };
-  }
-
-  _getRelativeBounds(target) {
-    return {
-      containerBounds: this._canvas.getContainer().getBoundingClientRect(),
-      targetBounds: this._canvas.getGraphics(target).getBoundingClientRect()
     };
   }
 

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -7,7 +7,7 @@ import CreatePad from '../../common/createPad/CreatePad';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-const CREATE_PAD_MARGIN = 28;
+import { APPEND_GAP, PAD_CONTENT_OFFSET, CREATE_PAD_MARGIN } from './constants';
 
 // leading pad entries, in this order; any other entries follow in natural order.
 // connect is relocated here from the context pad.
@@ -90,47 +90,38 @@ export default class AppendCreatePad extends CreatePad {
       return this._getBoundaryEventPosition(target);
     }
 
-    const container = this._canvas.getContainer();
-
-    const containerBounds = container.getBoundingClientRect();
-
-    const gfx = this._canvas.getGraphics(target);
-
-    const targetBounds = gfx.getBoundingClientRect();
-
-    let margin = CREATE_PAD_MARGIN;
-
-    if (this._rules.allowed('shape.resize', { shape: target })) {
-      margin = margin * 1.5;
-    }
+    const { x, y, width, height } = this._canvas.getAbsoluteBBox(target);
 
     return {
-      left: targetBounds.right + (margin * this._canvas.zoom()) - containerBounds.left,
-      top: targetBounds.top + targetBounds.height / 2 - containerBounds.top
+      left: x + width + APPEND_GAP * this._canvas.zoom() + PAD_CONTENT_OFFSET,
+      top: y + height / 2
     };
   }
 
   _getBoundaryEventPosition(target) {
     const orientation = getOrientation(getMid(target), target.host);
 
-    const container = this._canvas.getContainer();
+    const { containerBounds, targetBounds } = this._getRelativeBounds(target);
 
-    const containerBounds = container.getBoundingClientRect();
-
-    const gfx = this._canvas.getGraphics(target);
-
-    const targetBounds = gfx.getBoundingClientRect();
+    const margin = CREATE_PAD_MARGIN * this._canvas.zoom();
 
     if (orientation.includes('right') || orientation.includes('top') || orientation.includes('left')) {
       return {
-        left: targetBounds.right + (CREATE_PAD_MARGIN * this._canvas.zoom()) - containerBounds.left,
+        left: targetBounds.right + margin - containerBounds.left,
         top: targetBounds.top + targetBounds.height / 2 - containerBounds.top
       };
     }
 
     return {
       left: targetBounds.left + targetBounds.width / 2 - containerBounds.left,
-      top: targetBounds.bottom + (CREATE_PAD_MARGIN * this._canvas.zoom()) - containerBounds.top
+      top: targetBounds.bottom + margin - containerBounds.top
+    };
+  }
+
+  _getRelativeBounds(target) {
+    return {
+      containerBounds: this._canvas.getContainer().getBoundingClientRect(),
+      targetBounds: this._canvas.getGraphics(target).getBoundingClientRect()
     };
   }
 

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -20,13 +20,27 @@ const PAD_ENTRIES_ORDER = [
 ];
 
 export default class AppendCreatePad extends CreatePad {
-  constructor(canvas, contextPadProvider, eventBus, popupMenu, rules, translate) {
+  constructor(canvas, contextPadProvider, eventBus, popupMenu, rules, selection, translate) {
     super(canvas, eventBus, 'djs-append-create-pad');
 
     this._contextPadProvider = contextPadProvider;
     this._popupMenu = popupMenu;
     this._rules = rules;
+    this._selection = selection;
     this._translate = translate;
+
+    // direct editing is a dedicated mode where the user's context is the edit box,
+    // so step aside for its duration and reopen afterwards if its element is still
+    // the single selected one
+    eventBus.on('directEditing.activate', () => this.close());
+
+    eventBus.on('directEditing.deactivate', () => {
+      const selection = this._selection.get();
+
+      if (selection.length === 1) {
+        this.open(selection[0]);
+      }
+    });
   }
 
   canOpen(target) {
@@ -148,5 +162,6 @@ AppendCreatePad.$inject = [
   'eventBus',
   'popupMenu',
   'rules',
+  'selection',
   'translate'
 ];

--- a/lib/bpmn/appendCreatePad/constants.js
+++ b/lib/bpmn/appendCreatePad/constants.js
@@ -1,13 +1,10 @@
 // gap between an element's right edge and the "+", in diagram units; shared by
 // the indicator overlay and the append pad so the "+" doesn't move when the pad
-// opens (scales with zoom)
-export const APPEND_GAP = 17;
+// opens (scales with zoom). Kept clear of the selection outline.
+export const APPEND_GAP = 12;
 
 // the append pad's structural left offset, in px, that cancels its own CSS so the
 // first "+" box lines up with the indicator: it equals the pad's CSS translateX
 // (20px, see .djs-append-create-pad in create-pad.css) minus the 4px padding of
 // its entries row. Keep it in sync if either CSS value changes.
 export const PAD_CONTENT_OFFSET = 16;
-
-// gap between a boundary event and its create pad.
-export const CREATE_PAD_MARGIN = 28;

--- a/lib/bpmn/appendCreatePad/constants.js
+++ b/lib/bpmn/appendCreatePad/constants.js
@@ -1,0 +1,13 @@
+// gap between an element's right edge and the "+", in diagram units; shared by
+// the indicator overlay and the append pad so the "+" doesn't move when the pad
+// opens (scales with zoom)
+export const APPEND_GAP = 17;
+
+// the append pad's structural left offset, in px, that cancels its own CSS so the
+// first "+" box lines up with the indicator: it equals the pad's CSS translateX
+// (20px, see .djs-append-create-pad in create-pad.css) minus the 4px padding of
+// its entries row. Keep it in sync if either CSS value changes.
+export const PAD_CONTENT_OFFSET = 16;
+
+// gap between a boundary event and its create pad.
+export const CREATE_PAD_MARGIN = 28;

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -1,10 +1,9 @@
 import { isConnection } from 'diagram-js/lib/util/ModelUtil';
-import { getMid, getOrientation } from 'diagram-js/lib/layout/LayoutUtil';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-import { APPEND_GAP, CREATE_PAD_MARGIN, PAD_CONTENT_OFFSET } from '../appendCreatePad/constants';
+import { APPEND_GAP } from '../appendCreatePad/constants';
 
 const OVERLAY_TYPE = 'append-indicator';
 
@@ -13,55 +12,61 @@ const INDICATOR_SIZE = 28;
 // gap between the element's right edge and the indicator, in diagram units
 const INDICATOR_GAP = APPEND_GAP;
 
-// the indicator scales with the diagram zoom down to this factor; when the zoom
-// falls below it the indicator is hidden rather than shown tiny and off-center
+// below this zoom the indicator is hidden instead of shrinking further
 const MIN_SCALE = 0.3;
 
-// grace period before a hover-opened pad closes again, so the pointer can travel
-// from the indicator into the pad without it disappearing
+// delay before the pad closes, so the pointer can move from indicator to pad
 const CLOSE_DELAY_MS = 300;
 
-// a bottom-attached boundary event's pad renders its "+" a few pixels below the
-// symmetric position; nudge the indicator down by the same amount so it aligns
-const BOUNDARY_BOTTOM_NUDGE = 5;
-
 /**
- * Shows a persistent grey "+" next to every appendable element that has no
- * outgoing sequence flow, nudging the user to complete the path. Hovering it
- * opens the append menu; it hides while that menu is open.
+ * Shows a grey "+" next to every appendable element that has no outgoing
+ * sequence flow. Hovering it opens the append menu.
  */
 export default class AppendIndicator {
-  constructor(appendCreatePad, elementRegistry, eventBus, overlays, rules, selection, translate) {
+  constructor(appendCreatePad, elementRegistry, eventBus, overlays, selection, translate) {
     this._appendCreatePad = appendCreatePad;
     this._elementRegistry = elementRegistry;
     this._overlays = overlays;
-    this._rules = rules;
     this._selection = selection;
     this._translate = translate;
 
     this._closeTimeout = null;
 
-    // indicators hide while a drag or a direct edit is in progress
+    // indicators hide during a drag or direct edit
     this._dragging = false;
     this._editing = false;
     this._disabled = false;
 
-    // an indicator depends on the whole diagram (an element's own state and
-    // whether its slot is free of neighbors), so re-evaluate all of them
-    // whenever the diagram is loaded or changed
-    eventBus.on([ 'import.done', 'elements.changed' ], () => this._refreshAll());
+    // refresh all indicators on load
+    eventBus.on('import.done', () => this._refreshAll());
 
-    // hide the indicator while the append pad is open for its element
+    // refresh indicators for changed elements
+    eventBus.on('elements.changed', ({ elements }) => this._refreshChanged(elements));
+
+    // a connection's source and target aren't always in elements.changed;
+    // refresh both ends from the command context
+    const refreshFlowEnds = ({ context }) => {
+      [ context.source, context.target, context.oldSource, context.newSource ]
+        .forEach(element => this._refresh(element));
+    };
+
+    eventBus.on([
+      'commandStack.connection.create.reverted',
+      'commandStack.connection.reconnect.postExecuted',
+      'commandStack.connection.reconnect.reverted',
+      'commandStack.connection.delete.postExecuted'
+    ], refreshFlowEnds);
+
+    // hide the indicator while its append pad is open
     eventBus.on('createPad.open', ({ target }) => this._setVisible(target, false));
     eventBus.on('createPad.close', ({ target }) => {
       this._cancelClose();
 
-      // restore the element's indicator; _setVisible keeps it hidden while
-      // disabled, so a pad closing mid drag or edit does not reveal it
+      // restore the indicator; _setVisible keeps it hidden while disabled
       this._setVisible(target, true);
     });
 
-    // disable indicators for the duration of a drag or a direct edit, then restore
+    // hide indicators during a drag or direct edit, then restore them
     eventBus.on('drag.start', () => this._setDisabled({ dragging: true }));
     eventBus.on('drag.cleanup', () => this._setDisabled({ dragging: false }));
     eventBus.on('directEditing.activate', () => this._setDisabled({ editing: true }));
@@ -69,47 +74,13 @@ export default class AppendIndicator {
   }
 
   _canAdd(element) {
-    return !isConnection(element)
-      && element.parent // exclude the root
-      && !is(element.parent, 'bpmn:AdHocSubProcess') // completing the path is optional inside ad-hoc
-      && this._rules.allowed('shape.append', { element })
-      && !hasOutgoingSequenceFlow(element)
-      && this._hasSpace(element); // skip the optional indicator when it wouldn't fit
+    return element.parent // exclude the root
+      && !is(element.parent, 'bpmn:AdHocSubProcess') // order is free in ad-hoc, no path to complete
+      && this._appendCreatePad.canAppend(element)
+      && !hasOutgoingSequenceFlow(element);
   }
 
-  /**
-   * The indicator is an optional nudge, so we only show it when its slot next to
-   * the element is actually free: it must fit inside a containing sub-process /
-   * participant and must not overlap a neighboring shape.
-   */
-  _hasSpace(element) {
-    const position = this._getPosition(element);
-
-    const slot = {
-      x: element.x + position.left,
-      y: element.y + position.top,
-      width: INDICATOR_SIZE,
-      height: INDICATOR_SIZE
-    };
-
-    const parent = element.parent;
-
-    // only a bounded container constrains the slot; the process root is unbounded,
-    // so an element sitting directly on it (its parent has no parent) always fits
-    if (parent.parent && !fitsInside(slot, parent)) {
-      return false;
-    }
-
-    // a boundary event overlaps its host by design, so the host never blocks it
-    return !parent.children.some(
-      sibling => sibling !== element
-        && sibling !== element.host
-        && isObstacle(sibling)
-        && intersects(slot, sibling)
-    );
-  }
-
-  _add(element) {
+  _add(element, position) {
     const html = document.createElement('div');
 
     html.className = 'djs-append-indicator';
@@ -119,9 +90,8 @@ export default class AppendIndicator {
 
     html.addEventListener('mouseenter', () => this._openMenu(element));
 
-
     this._overlays.add(element, OVERLAY_TYPE, {
-      position: this._getPosition(element),
+      position,
       scale: { min: MIN_SCALE },
       show: { minZoom: MIN_SCALE },
       html
@@ -134,16 +104,34 @@ export default class AppendIndicator {
     }
   }
 
-  // re-evaluate the indicator of every element
+  // refresh every element's indicator
   _refreshAll() {
     this._elementRegistry.forEach(element => this._refresh(element));
   }
 
-  /**
-   * Add, remove or reposition an element's indicator to match its current state,
-   * touching the overlay only when it actually needs to change.
-   */
+  // refresh the changed elements, plus both ends of any changed connection
+  // (their indicators depend on their outgoing flows)
+  _refreshChanged(elements) {
+    const dirty = new Set();
+
+    elements.forEach(element => {
+      dirty.add(element);
+
+      if (isConnection(element)) {
+        element.source && dirty.add(element.source);
+        element.target && dirty.add(element.target);
+      }
+    });
+
+    dirty.forEach(element => this._refresh(element));
+  }
+
+  // add, remove or reposition an element's indicator to match its current state
   _refresh(element) {
+    if (!element) {
+      return;
+    }
+
     const [ existing ] = this._overlays.get({ element, type: OVERLAY_TYPE });
 
     if (!this._canAdd(element)) {
@@ -168,36 +156,13 @@ export default class AppendIndicator {
       this._remove(element);
     }
 
-    this._add(element);
+    this._add(element, position);
   }
 
-  // the indicator sits just past the element's right edge, vertically centered
   _getPosition(element) {
-    if (is(element, 'bpmn:BoundaryEvent') && element.host) {
-      return this._getBoundaryEventPosition(element);
-    }
-
     return {
       left: element.width + INDICATOR_GAP,
       top: element.height / 2 - INDICATOR_SIZE / 2
-    };
-  }
-
-  // a boundary event sits on its host's border,
-  // so the indicator goes on the outer side and mirrors where AppendCreatePad opens the pad
-  _getBoundaryEventPosition(element) {
-    const orientation = getOrientation(getMid(element), element.host);
-
-    if (orientation.includes('right') || orientation.includes('top') || orientation.includes('left')) {
-      return {
-        left: element.width + CREATE_PAD_MARGIN - PAD_CONTENT_OFFSET,
-        top: element.height / 2 - INDICATOR_SIZE / 2
-      };
-    }
-
-    return {
-      left: element.width / 2 - PAD_CONTENT_OFFSET,
-      top: element.height + CREATE_PAD_MARGIN - INDICATOR_SIZE / 2 + BOUNDARY_BOTTOM_NUDGE
     };
   }
 
@@ -206,15 +171,14 @@ export default class AppendIndicator {
       return;
     }
 
-    // never reveal an indicator while disabled; the disabled flow restores them
+    // never reveal an indicator while disabled
     this._setOverlaysVisibility(
       this._overlays.get({ element, type: OVERLAY_TYPE }),
       visible && !this._disabled
     );
   }
 
-  // update a disable reason and hide or restore every indicator accordingly;
-  // indicators only come back once neither a drag nor an edit is in progress
+  // hide or restore all indicators; they return only when neither dragging nor editing
   _setDisabled({ dragging = this._dragging, editing = this._editing }) {
     this._dragging = dragging;
     this._editing = editing;
@@ -256,9 +220,7 @@ export default class AppendIndicator {
     this._closeTimeout = setTimeout(() => this._closeOrRestoreSelection(), CLOSE_DELAY_MS);
   }
 
-  // hovering another element's indicator opens its pad in place of the selected
-  // element's; when that hover ends, reopen the selected element's pad (if any)
-  // instead of leaving no pad open
+  // reopen the selected element's pad instead of leaving none open
   _closeOrRestoreSelection() {
     const selection = this._selection.get();
 
@@ -284,36 +246,11 @@ function hasOutgoingSequenceFlow(element) {
   );
 }
 
-// whether a neighbor is a real shape the indicator's slot could clash with.
-// Only space-occupying shapes count, so connections (lines, not areas), labels
-// (floating text) and lanes (full-width swimlane bands, not obstacles) are skipped.
-function isObstacle(element) {
-  return element.width != null
-    && !element.waypoints
-    && !element.labelTarget
-    && !is(element, 'bpmn:Lane');
-}
-
-function intersects(a, b) {
-  return a.x < b.x + b.width
-    && a.x + a.width > b.x
-    && a.y < b.y + b.height
-    && a.y + a.height > b.y;
-}
-
-function fitsInside(inner, outer) {
-  return inner.x >= outer.x
-    && inner.y >= outer.y
-    && inner.x + inner.width <= outer.x + outer.width
-    && inner.y + inner.height <= outer.y + outer.height;
-}
-
 AppendIndicator.$inject = [
   'appendCreatePad',
   'elementRegistry',
   'eventBus',
   'overlays',
-  'rules',
   'selection',
   'translate'
 ];

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -1,9 +1,10 @@
 import { isConnection } from 'diagram-js/lib/util/ModelUtil';
+import { getMid, getOrientation } from 'diagram-js/lib/layout/LayoutUtil';
 import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-import { APPEND_GAP } from '../appendCreatePad/constants';
+import { APPEND_GAP, CREATE_PAD_MARGIN, PAD_CONTENT_OFFSET } from '../appendCreatePad/constants';
 
 const OVERLAY_TYPE = 'append-indicator';
 
@@ -20,6 +21,10 @@ const MIN_SCALE = 0.3;
 // from the indicator into the pad without it disappearing
 const CLOSE_DELAY_MS = 300;
 
+// a bottom-attached boundary event's pad renders its "+" a few pixels below the
+// symmetric position; nudge the indicator down by the same amount so it aligns
+const BOUNDARY_BOTTOM_NUDGE = 5;
+
 /**
  * Shows a persistent grey "+" next to every appendable element that has no
  * outgoing sequence flow, nudging the user to complete the path. Hovering it
@@ -35,7 +40,11 @@ export default class AppendIndicator {
     this._translate = translate;
 
     this._closeTimeout = null;
+
+    // indicators hide while a drag or a direct edit is in progress
     this._dragging = false;
+    this._editing = false;
+    this._disabled = false;
 
     // an indicator depends on the whole diagram (an element's own state and
     // whether its slot is free of neighbors), so re-evaluate all of them
@@ -47,23 +56,16 @@ export default class AppendIndicator {
     eventBus.on('createPad.close', ({ target }) => {
       this._cancelClose();
 
-      // closing the pad normally restores its element's indicator, but when the
-      // pad closed because a drag began, indicators stay hidden until the drag ends
-      if (!this._dragging) {
-        this._setVisible(target, true);
-      }
+      // restore the element's indicator; _setVisible keeps it hidden while
+      // disabled, so a pad closing mid drag or edit does not reveal it
+      this._setVisible(target, true);
     });
 
-    // hide every indicator for the duration of a drag, otherwise dragging the
-    // pointer across one would open its hover menu; restore them when the drag ends
-    eventBus.on('drag.start', () => {
-      this._dragging = true;
-      this._setAllVisible(false);
-    });
-    eventBus.on('drag.cleanup', () => {
-      this._dragging = false;
-      this._setAllVisible(true);
-    });
+    // disable indicators for the duration of a drag or a direct edit, then restore
+    eventBus.on('drag.start', () => this._setDisabled({ dragging: true }));
+    eventBus.on('drag.cleanup', () => this._setDisabled({ dragging: false }));
+    eventBus.on('directEditing.activate', () => this._setDisabled({ editing: true }));
+    eventBus.on('directEditing.deactivate', () => this._setDisabled({ editing: false }));
   }
 
   _canAdd(element) {
@@ -81,9 +83,11 @@ export default class AppendIndicator {
    * participant and must not overlap a neighboring shape.
    */
   _hasSpace(element) {
+    const position = this._getPosition(element);
+
     const slot = {
-      x: element.x + element.width + INDICATOR_GAP,
-      y: element.y + element.height / 2 - INDICATOR_SIZE / 2,
+      x: element.x + position.left,
+      y: element.y + position.top,
       width: INDICATOR_SIZE,
       height: INDICATOR_SIZE
     };
@@ -96,8 +100,12 @@ export default class AppendIndicator {
       return false;
     }
 
+    // a boundary event overlaps its host by design, so the host never blocks it
     return !parent.children.some(
-      sibling => sibling !== element && isObstacle(sibling) && intersects(slot, sibling)
+      sibling => sibling !== element
+        && sibling !== element.host
+        && isObstacle(sibling)
+        && intersects(slot, sibling)
     );
   }
 
@@ -110,6 +118,7 @@ export default class AppendIndicator {
     html.innerHTML = icons.createElement;
 
     html.addEventListener('mouseenter', () => this._openMenu(element));
+
 
     this._overlays.add(element, OVERLAY_TYPE, {
       position: this._getPosition(element),
@@ -164,9 +173,31 @@ export default class AppendIndicator {
 
   // the indicator sits just past the element's right edge, vertically centered
   _getPosition(element) {
+    if (is(element, 'bpmn:BoundaryEvent') && element.host) {
+      return this._getBoundaryEventPosition(element);
+    }
+
     return {
       left: element.width + INDICATOR_GAP,
       top: element.height / 2 - INDICATOR_SIZE / 2
+    };
+  }
+
+  // a boundary event sits on its host's border,
+  // so the indicator goes on the outer side and mirrors where AppendCreatePad opens the pad
+  _getBoundaryEventPosition(element) {
+    const orientation = getOrientation(getMid(element), element.host);
+
+    if (orientation.includes('right') || orientation.includes('top') || orientation.includes('left')) {
+      return {
+        left: element.width + CREATE_PAD_MARGIN - PAD_CONTENT_OFFSET,
+        top: element.height / 2 - INDICATOR_SIZE / 2
+      };
+    }
+
+    return {
+      left: element.width / 2 - PAD_CONTENT_OFFSET,
+      top: element.height + CREATE_PAD_MARGIN - INDICATOR_SIZE / 2 + BOUNDARY_BOTTOM_NUDGE
     };
   }
 
@@ -175,15 +206,29 @@ export default class AppendIndicator {
       return;
     }
 
-    this._setOverlaysVisible(this._overlays.get({ element, type: OVERLAY_TYPE }), visible);
+    // never reveal an indicator while disabled; the disabled flow restores them
+    this._setOverlaysVisibility(
+      this._overlays.get({ element, type: OVERLAY_TYPE }),
+      visible && !this._disabled
+    );
   }
 
-  // toggle every indicator at once, e.g. to get them out of the way during drag interaction
+  // update a disable reason and hide or restore every indicator accordingly;
+  // indicators only come back once neither a drag nor an edit is in progress
+  _setDisabled({ dragging = this._dragging, editing = this._editing }) {
+    this._dragging = dragging;
+    this._editing = editing;
+
+    this._disabled = dragging || editing;
+
+    this._setAllVisible(!this._disabled);
+  }
+
   _setAllVisible(visible) {
-    this._setOverlaysVisible(this._overlays.get({ type: OVERLAY_TYPE }), visible);
+    this._setOverlaysVisibility(this._overlays.get({ type: OVERLAY_TYPE }), visible);
   }
 
-  _setOverlaysVisible(overlays, visible) {
+  _setOverlaysVisibility(overlays, visible) {
     overlays.forEach(overlay => {
       overlay.html.style.display = visible ? '' : 'none';
     });

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -28,6 +28,7 @@ const CLOSE_DELAY_MS = 300;
 export default class AppendIndicator {
   constructor(appendCreatePad, elementRegistry, eventBus, overlays, rules, selection, translate) {
     this._appendCreatePad = appendCreatePad;
+    this._elementRegistry = elementRegistry;
     this._overlays = overlays;
     this._rules = rules;
     this._selection = selection;
@@ -36,57 +37,10 @@ export default class AppendIndicator {
     this._closeTimeout = null;
     this._dragging = false;
 
-    eventBus.on('import.done', () => {
-      elementRegistry.forEach(element => this._refresh(element));
-    });
-
-    // a shape appearing, moving or resizing can change its own eligibility and
-    // free up or take away the slot of its neighbors and children
-    eventBus.on([ 'shape.added', 'shape.changed' ], ({ element }) => {
-      this._refreshNeighborhood(element);
-    });
-
-    // deleting a shape can free up the slot of a former neighbor, so reconcile
-    // the shapes that lived alongside it (its old parent's children)
-    eventBus.on('commandStack.shape.delete.postExecuted', ({ context }) => {
-      this._refreshNeighborhood(null, context.oldParent);
-    });
-
-    // moving a shape into another parent frees the slot it held in its old one;
-    // the shape's own move refreshes the new parent, so only the old parent's
-    // remaining children still need reconciling here
-    eventBus.on('commandStack.shape.move.postExecuted', ({ context }) => {
-      const { oldParent, shape } = context;
-
-      if (oldParent && oldParent !== shape.parent) {
-        this._refreshNeighborhood(null, oldParent);
-      }
-    });
-
-    // a sequence flow completing the path removes the source's indicator
-    eventBus.on('connection.added', ({ element }) => {
-      if (is(element, 'bpmn:SequenceFlow')) {
-        this._refresh(element.source);
-      }
-    });
-
-    // removing a sequence flow can turn its source back into a dangling end, so
-    // re-evaluate the source — excluding this flow, which is still attached to it
-    eventBus.on('connection.removed', ({ element }) => {
-      if (is(element, 'bpmn:SequenceFlow')) {
-        this._refresh(element.source, element);
-      }
-    });
-
-    // moving a sequence flow's start to another element makes the old source a
-    // dangling end again and completes the path for the new one; re-evaluate both
-    eventBus.on('commandStack.connection.reconnect.postExecuted', ({ context }) => {
-      const { connection, oldSource } = context;
-
-      if (is(connection, 'bpmn:SequenceFlow')) {
-        [ oldSource, connection.source ].forEach(source => source && this._refresh(source));
-      }
-    });
+    // an indicator depends on the whole diagram (an element's own state and
+    // whether its slot is free of neighbors), so re-evaluate all of them
+    // whenever the diagram is loaded or changed
+    eventBus.on([ 'import.done', 'elements.changed' ], () => this._refreshAll());
 
     // hide the indicator while the append pad is open for its element
     eventBus.on('createPad.open', ({ target }) => this._setVisible(target, false));
@@ -112,12 +66,12 @@ export default class AppendIndicator {
     });
   }
 
-  _canAdd(element, ignoreConnection) {
+  _canAdd(element) {
     return !isConnection(element)
       && element.parent // exclude the root
       && !is(element.parent, 'bpmn:AdHocSubProcess') // completing the path is optional inside ad-hoc
       && this._rules.allowed('shape.append', { element })
-      && !hasOutgoingSequenceFlow(element, ignoreConnection)
+      && !hasOutgoingSequenceFlow(element)
       && this._hasSpace(element); // skip the optional indicator when it wouldn't fit
   }
 
@@ -158,10 +112,7 @@ export default class AppendIndicator {
     html.addEventListener('mouseenter', () => this._openMenu(element));
 
     this._overlays.add(element, OVERLAY_TYPE, {
-      position: {
-        left: element.width + INDICATOR_GAP,
-        top: element.height / 2 - INDICATOR_SIZE / 2
-      },
+      position: this._getPosition(element),
       scale: { min: MIN_SCALE },
       show: { minZoom: MIN_SCALE },
       html
@@ -174,32 +125,49 @@ export default class AppendIndicator {
     }
   }
 
-  /**
-   * Reconcile an element's indicator with its current eligibility and position.
-   * Removing first keeps the position fresh after a resize and prevents
-   * duplicates, so this is safe to call for any element at any time.
-   */
-  _refresh(element, ignoreConnection) {
-    this._remove(element);
-
-    if (this._canAdd(element, ignoreConnection)) {
-      this._add(element);
-    }
+  // re-evaluate the indicator of every element
+  _refreshAll() {
+    this._elementRegistry.forEach(element => this._refresh(element));
   }
 
-  // reconcile an element and every element a change to it could affect: its
-  // siblings (which it may overlap) and its children (which it may contain).
-  // Pass the parent explicitly when the element is already detached (removal).
-  _refreshNeighborhood(element, parent = element && element.parent) {
-    const affected = new Set(parent ? parent.children : []);
+  /**
+   * Add, remove or reposition an element's indicator to match its current state,
+   * touching the overlay only when it actually needs to change.
+   */
+  _refresh(element) {
+    const [ existing ] = this._overlays.get({ element, type: OVERLAY_TYPE });
 
-    if (element) {
-      affected.add(element);
+    if (!this._canAdd(element)) {
+      if (existing) {
+        this._remove(element);
+      }
 
-      (element.children || []).forEach(child => affected.add(child));
+      return;
     }
 
-    affected.forEach(el => this._refresh(el));
+    const position = this._getPosition(element);
+
+    // already in the right place, nothing to do
+    if (existing
+        && existing.position.left === position.left
+        && existing.position.top === position.top) {
+      return;
+    }
+
+    // position changed (e.g. after a resize); re-add to move it
+    if (existing) {
+      this._remove(element);
+    }
+
+    this._add(element);
+  }
+
+  // the indicator sits just past the element's right edge, vertically centered
+  _getPosition(element) {
+    return {
+      left: element.width + INDICATOR_GAP,
+      top: element.height / 2 - INDICATOR_SIZE / 2
+    };
   }
 
   _setVisible(element, visible) {
@@ -265,9 +233,9 @@ export default class AppendIndicator {
   }
 }
 
-function hasOutgoingSequenceFlow(element, ignoreConnection) {
+function hasOutgoingSequenceFlow(element) {
   return element.outgoing && element.outgoing.some(
-    connection => connection !== ignoreConnection && is(connection, 'bpmn:SequenceFlow')
+    connection => is(connection, 'bpmn:SequenceFlow')
   );
 }
 

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -24,9 +24,6 @@ const CLOSE_DELAY_MS = 300;
  * Shows a persistent grey "+" next to every appendable element that has no
  * outgoing sequence flow, nudging the user to complete the path. Hovering it
  * opens the append menu; it hides while that menu is open.
- *
- * Positioning, zooming and removal-on-delete are handled by the overlays
- * service, so this class only owns "which elements qualify" and the hover.
  */
 export default class AppendIndicator {
   constructor(appendCreatePad, elementRegistry, eventBus, overlays, rules, selection, translate) {

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -55,6 +55,17 @@ export default class AppendIndicator {
       this._refreshNeighborhood(null, context.oldParent);
     });
 
+    // moving a shape into another parent frees the slot it held in its old one;
+    // the shape's own move refreshes the new parent, so only the old parent's
+    // remaining children still need reconciling here
+    eventBus.on('commandStack.shape.move.postExecuted', ({ context }) => {
+      const { oldParent, shape } = context;
+
+      if (oldParent && oldParent !== shape.parent) {
+        this._refreshNeighborhood(null, oldParent);
+      }
+    });
+
     // a sequence flow completing the path removes the source's indicator
     eventBus.on('connection.added', ({ element }) => {
       if (is(element, 'bpmn:SequenceFlow')) {

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -1,0 +1,298 @@
+import { isConnection } from 'diagram-js/lib/util/ModelUtil';
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+import icons from '../../common/contextPad/ContextPadIcons';
+
+import { APPEND_GAP } from '../appendCreatePad/constants';
+
+const OVERLAY_TYPE = 'append-indicator';
+
+const INDICATOR_SIZE = 28;
+
+// gap between the element's right edge and the indicator, in diagram units
+const INDICATOR_GAP = APPEND_GAP;
+
+// the indicator scales with the diagram zoom down to this factor; when the zoom
+// falls below it the indicator is hidden rather than shown tiny and off-center
+const MIN_SCALE = 0.3;
+
+// grace period before a hover-opened pad closes again, so the pointer can travel
+// from the indicator into the pad without it disappearing
+const CLOSE_DELAY_MS = 300;
+
+/**
+ * Shows a persistent grey "+" next to every appendable element that has no
+ * outgoing sequence flow, nudging the user to complete the path. Hovering it
+ * opens the append menu; it hides while that menu is open.
+ *
+ * Positioning, zooming and removal-on-delete are handled by the overlays
+ * service, so this class only owns "which elements qualify" and the hover.
+ */
+export default class AppendIndicator {
+  constructor(appendCreatePad, elementRegistry, eventBus, overlays, rules, selection, translate) {
+    this._appendCreatePad = appendCreatePad;
+    this._overlays = overlays;
+    this._rules = rules;
+    this._selection = selection;
+    this._translate = translate;
+
+    this._closeTimeout = null;
+    this._dragging = false;
+
+    eventBus.on('import.done', () => {
+      elementRegistry.forEach(element => this._refresh(element));
+    });
+
+    // a shape appearing, moving or resizing can change its own eligibility and
+    // free up or take away the slot of its neighbors and children
+    eventBus.on([ 'shape.added', 'shape.changed' ], ({ element }) => {
+      this._refreshNeighborhood(element);
+    });
+
+    // deleting a shape can free up the slot of a former neighbor, so reconcile
+    // the shapes that lived alongside it (its old parent's children)
+    eventBus.on('commandStack.shape.delete.postExecuted', ({ context }) => {
+      this._refreshNeighborhood(null, context.oldParent);
+    });
+
+    // a sequence flow completing the path removes the source's indicator
+    eventBus.on('connection.added', ({ element }) => {
+      if (is(element, 'bpmn:SequenceFlow')) {
+        this._refresh(element.source);
+      }
+    });
+
+    // removing a sequence flow can turn its source back into a dangling end, so
+    // re-evaluate the source — excluding this flow, which is still attached to it
+    eventBus.on('connection.removed', ({ element }) => {
+      if (is(element, 'bpmn:SequenceFlow')) {
+        this._refresh(element.source, element);
+      }
+    });
+
+    // moving a sequence flow's start to another element makes the old source a
+    // dangling end again and completes the path for the new one; re-evaluate both
+    eventBus.on('commandStack.connection.reconnect.postExecuted', ({ context }) => {
+      const { connection, oldSource } = context;
+
+      if (is(connection, 'bpmn:SequenceFlow')) {
+        [ oldSource, connection.source ].forEach(source => source && this._refresh(source));
+      }
+    });
+
+    // hide the indicator while the append pad is open for its element
+    eventBus.on('createPad.open', ({ target }) => this._setVisible(target, false));
+    eventBus.on('createPad.close', ({ target }) => {
+      this._cancelClose();
+
+      // closing the pad normally restores its element's indicator, but when the
+      // pad closed because a drag began, indicators stay hidden until the drag ends
+      if (!this._dragging) {
+        this._setVisible(target, true);
+      }
+    });
+
+    // hide every indicator for the duration of a drag, otherwise dragging the
+    // pointer across one would open its hover menu; restore them when the drag ends
+    eventBus.on('drag.start', () => {
+      this._dragging = true;
+      this._setAllVisible(false);
+    });
+    eventBus.on('drag.cleanup', () => {
+      this._dragging = false;
+      this._setAllVisible(true);
+    });
+  }
+
+  _canAdd(element, ignoreConnection) {
+    return !isConnection(element)
+      && element.parent // exclude the root
+      && !is(element.parent, 'bpmn:AdHocSubProcess') // completing the path is optional inside ad-hoc
+      && this._rules.allowed('shape.append', { element })
+      && !hasOutgoingSequenceFlow(element, ignoreConnection)
+      && this._hasSpace(element); // skip the optional indicator when it wouldn't fit
+  }
+
+  /**
+   * The indicator is an optional nudge, so we only show it when its slot next to
+   * the element is actually free: it must fit inside a containing sub-process /
+   * participant and must not overlap a neighboring shape.
+   */
+  _hasSpace(element) {
+    const slot = {
+      x: element.x + element.width + INDICATOR_GAP,
+      y: element.y + element.height / 2 - INDICATOR_SIZE / 2,
+      width: INDICATOR_SIZE,
+      height: INDICATOR_SIZE
+    };
+
+    const parent = element.parent;
+
+    // only a bounded container constrains the slot; the process root is unbounded,
+    // so an element sitting directly on it (its parent has no parent) always fits
+    if (parent.parent && !fitsInside(slot, parent)) {
+      return false;
+    }
+
+    return !parent.children.some(
+      sibling => sibling !== element && isObstacle(sibling) && intersects(slot, sibling)
+    );
+  }
+
+  _add(element) {
+    const html = document.createElement('div');
+
+    html.className = 'djs-append-indicator';
+    html.title = this._translate('Append element');
+    html.setAttribute('data-element', element.id);
+    html.innerHTML = icons.createElement;
+
+    html.addEventListener('mouseenter', () => this._openMenu(element));
+
+    this._overlays.add(element, OVERLAY_TYPE, {
+      position: {
+        left: element.width + INDICATOR_GAP,
+        top: element.height / 2 - INDICATOR_SIZE / 2
+      },
+      scale: { min: MIN_SCALE },
+      show: { minZoom: MIN_SCALE },
+      html
+    });
+  }
+
+  _remove(element) {
+    if (element) {
+      this._overlays.remove({ element, type: OVERLAY_TYPE });
+    }
+  }
+
+  /**
+   * Reconcile an element's indicator with its current eligibility and position.
+   * Removing first keeps the position fresh after a resize and prevents
+   * duplicates, so this is safe to call for any element at any time.
+   */
+  _refresh(element, ignoreConnection) {
+    this._remove(element);
+
+    if (this._canAdd(element, ignoreConnection)) {
+      this._add(element);
+    }
+  }
+
+  // reconcile an element and every element a change to it could affect: its
+  // siblings (which it may overlap) and its children (which it may contain).
+  // Pass the parent explicitly when the element is already detached (removal).
+  _refreshNeighborhood(element, parent = element && element.parent) {
+    const affected = new Set(parent ? parent.children : []);
+
+    if (element) {
+      affected.add(element);
+
+      (element.children || []).forEach(child => affected.add(child));
+    }
+
+    affected.forEach(el => this._refresh(el));
+  }
+
+  _setVisible(element, visible) {
+    if (!element) {
+      return;
+    }
+
+    this._setOverlaysVisible(this._overlays.get({ element, type: OVERLAY_TYPE }), visible);
+  }
+
+  // toggle every indicator at once, e.g. to get them out of the way during drag interaction
+  _setAllVisible(visible) {
+    this._setOverlaysVisible(this._overlays.get({ type: OVERLAY_TYPE }), visible);
+  }
+
+  _setOverlaysVisible(overlays, visible) {
+    overlays.forEach(overlay => {
+      overlay.html.style.display = visible ? '' : 'none';
+    });
+  }
+
+  _openMenu(element) {
+    this._cancelClose();
+
+    this._appendCreatePad.open(element);
+
+    const html = this._appendCreatePad.getHtml();
+
+    if (!html) {
+      return;
+    }
+
+    // close again shortly after the pointer leaves the pad
+    html.addEventListener('mouseenter', () => this._cancelClose());
+    html.addEventListener('mouseleave', () => this._scheduleClose());
+  }
+
+  _scheduleClose() {
+    this._cancelClose();
+
+    this._closeTimeout = setTimeout(() => this._closeOrRestoreSelection(), CLOSE_DELAY_MS);
+  }
+
+  // hovering another element's indicator opens its pad in place of the selected
+  // element's; when that hover ends, reopen the selected element's pad (if any)
+  // instead of leaving no pad open
+  _closeOrRestoreSelection() {
+    const selection = this._selection.get();
+
+    if (selection.length === 1) {
+      this._appendCreatePad.open(selection[0]);
+    } else {
+      this._appendCreatePad.close();
+    }
+  }
+
+  _cancelClose() {
+    if (this._closeTimeout) {
+      clearTimeout(this._closeTimeout);
+
+      this._closeTimeout = null;
+    }
+  }
+}
+
+function hasOutgoingSequenceFlow(element, ignoreConnection) {
+  return element.outgoing && element.outgoing.some(
+    connection => connection !== ignoreConnection && is(connection, 'bpmn:SequenceFlow')
+  );
+}
+
+// whether a neighbor is a real shape the indicator's slot could clash with.
+// Only space-occupying shapes count, so connections (lines, not areas), labels
+// (floating text) and lanes (full-width swimlane bands, not obstacles) are skipped.
+function isObstacle(element) {
+  return element.width != null
+    && !element.waypoints
+    && !element.labelTarget
+    && !is(element, 'bpmn:Lane');
+}
+
+function intersects(a, b) {
+  return a.x < b.x + b.width
+    && a.x + a.width > b.x
+    && a.y < b.y + b.height
+    && a.y + a.height > b.y;
+}
+
+function fitsInside(inner, outer) {
+  return inner.x >= outer.x
+    && inner.y >= outer.y
+    && inner.x + inner.width <= outer.x + outer.width
+    && inner.y + inner.height <= outer.y + outer.height;
+}
+
+AppendIndicator.$inject = [
+  'appendCreatePad',
+  'elementRegistry',
+  'eventBus',
+  'overlays',
+  'rules',
+  'selection',
+  'translate'
+];

--- a/lib/bpmn/appendIndicator/index.js
+++ b/lib/bpmn/appendIndicator/index.js
@@ -1,0 +1,9 @@
+import AppendIndicator from './AppendIndicator';
+
+import AppendCreatePadModule from '../appendCreatePad';
+
+export default {
+  __depends__: [ AppendCreatePadModule ],
+  __init__: [ 'appendIndicator' ],
+  appendIndicator: [ 'type', AppendIndicator ]
+};

--- a/lib/bpmn/contextPad/ImprovedContextPadProvider.js
+++ b/lib/bpmn/contextPad/ImprovedContextPadProvider.js
@@ -13,9 +13,9 @@ import {
 
 const VERY_LOW_PRIORITY = 100;
 
-export default function BPMNImprovedContextPadProvider(contextPad, eventBus, popupMenu) {
+export default function BPMNImprovedContextPadProvider(canvas, contextPad, eventBus, popupMenu) {
+  this._canvas = canvas;
   this._eventBus = eventBus;
-  this._contextPad = contextPad;
   this._popupMenu = popupMenu;
 
   contextPad.registerProvider(VERY_LOW_PRIORITY, this);
@@ -141,7 +141,7 @@ BPMNImprovedContextPadProvider.prototype.getMultiElementContextPadEntries = func
 BPMNImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function(entry, menuId) {
   entry.action = {
     click: (event, target) => {
-      const position = this._getMenuPosition(target);
+      const position = this._getMenuPosition();
 
       assign(position, {
         cursor: {
@@ -155,10 +155,10 @@ BPMNImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function
   };
 };
 
-BPMNImprovedContextPadProvider.prototype._getMenuPosition = function(elements) {
+BPMNImprovedContextPadProvider.prototype._getMenuPosition = function() {
   const Y_OFFSET = 5;
 
-  const pad = this._contextPad.getPad(elements).html;
+  const pad = this._canvas.getContainer().querySelector('.djs-context-pad');
 
   const padRect = pad.getBoundingClientRect();
 
@@ -170,4 +170,4 @@ BPMNImprovedContextPadProvider.prototype._getMenuPosition = function(elements) {
   return pos;
 };
 
-BPMNImprovedContextPadProvider.$inject = [ 'contextPad', 'eventBus', 'popupMenu' ];
+BPMNImprovedContextPadProvider.$inject = [ 'canvas', 'contextPad', 'eventBus', 'popupMenu' ];

--- a/lib/bpmn/index.js
+++ b/lib/bpmn/index.js
@@ -4,6 +4,7 @@ import improvedPopupMenu from './popupMenu';
 import resourceLinking from './resourceLinking';
 import showComments from './showComments';
 import appendCreatePad from './appendCreatePad';
+import appendIndicator from './appendIndicator';
 import improvedPalette from './palette';
 
 export default {
@@ -12,6 +13,7 @@ export default {
     improvedContextPad,
     improvedPopupMenu,
     appendCreatePad,
+    appendIndicator,
     resourceLinking,
     showComments,
     improvedPalette

--- a/lib/common/contextPad/ImprovedContextPad.js
+++ b/lib/common/contextPad/ImprovedContextPad.js
@@ -29,6 +29,8 @@ export default function ImprovedContextPad(canvas, contextPad, eventBus, injecto
   this._contextPad = contextPad;
   this._injector = injector;
 
+  this._editing = false;
+
   contextPad._getPosition = this._getPosition.bind(this);
   contextPad._updateVisibility = this._updateVisibility.bind(this);
 
@@ -37,10 +39,29 @@ export default function ImprovedContextPad(canvas, contextPad, eventBus, injecto
   eventBus.on('canvas.viewbox.changed', () => {
     this._updateVisibility();
   });
+
+  // direct editing is a dedicated mode where the user's context is the edit box,
+  // so keep the context pad out of the way for its duration and bring it back
+  // once editing completes or is cancelled
+  eventBus.on('directEditing.activate', () => {
+    this._editing = true;
+    this._contextPad.hide();
+  });
+
+  eventBus.on('directEditing.deactivate', () => {
+    this._editing = false;
+    this._updateVisibility();
+  });
 }
 
 ImprovedContextPad.prototype._updateVisibility = function() {
   if (!this._contextPad.isOpen()) {
+    return;
+  }
+
+  if (this._editing) {
+    this._contextPad.hide();
+
     return;
   }
 

--- a/lib/common/contextPad/ImprovedContextPadProvider.js
+++ b/lib/common/contextPad/ImprovedContextPadProvider.js
@@ -11,9 +11,9 @@ import {
 
 const VERY_LOW_PRIORITY = 100;
 
-export default function ImprovedContextPadProvider(contextPad, eventBus, popupMenu) {
+export default function ImprovedContextPadProvider(canvas, contextPad, eventBus, popupMenu) {
+  this._canvas = canvas;
   this._eventBus = eventBus;
-  this._contextPad = contextPad;
   this._popupMenu = popupMenu;
 
   contextPad.registerProvider(VERY_LOW_PRIORITY, this);
@@ -79,7 +79,7 @@ ImprovedContextPadProvider.prototype.getMultiElementContextPadEntries = function
 ImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function(entry, menuId) {
   entry.action = {
     click: (event, target) => {
-      const position = this._getMenuPosition(target);
+      const position = this._getMenuPosition();
 
       assign(position, {
         cursor: {
@@ -93,10 +93,10 @@ ImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function(ent
   };
 };
 
-ImprovedContextPadProvider.prototype._getMenuPosition = function(elements) {
+ImprovedContextPadProvider.prototype._getMenuPosition = function() {
   const Y_OFFSET = 5;
 
-  const pad = this._contextPad.getPad(elements).html;
+  const pad = this._canvas.getContainer().querySelector('.djs-context-pad');
 
   const padRect = pad.getBoundingClientRect();
 
@@ -108,7 +108,7 @@ ImprovedContextPadProvider.prototype._getMenuPosition = function(elements) {
   return pos;
 };
 
-ImprovedContextPadProvider.$inject = [ 'contextPad', 'eventBus', 'popupMenu' ];
+ImprovedContextPadProvider.$inject = [ 'canvas', 'contextPad', 'eventBus', 'popupMenu' ];
 
 // helpers //////////
 export function getEntry(entries, id) {

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -295,7 +295,7 @@ describe('<AppendCreatePad>', function() {
     }));
 
 
-    it('should return position for boundary event (bottom)', inject(function(appendCreatePad, canvas, elementRegistry) {
+    it('should place the pad to the right for a bottom-attached boundary event', inject(function(appendCreatePad, canvas, elementRegistry) {
 
       // given
       const boundaryEvent = elementRegistry.get('CompensationBoundaryEvent_1');
@@ -303,7 +303,7 @@ describe('<AppendCreatePad>', function() {
       // when
       const position = appendCreatePad.getPosition(boundaryEvent);
 
-      // then
+      // then the pad opens to the right, clear of the label below the event
       const gfx = canvas.getGraphics(boundaryEvent);
 
       const targetBounds = gfx.getBoundingClientRect();
@@ -312,8 +312,8 @@ describe('<AppendCreatePad>', function() {
 
       const containerBounds = container.getBoundingClientRect();
 
-      expect(position.left).to.be.closeTo(targetBounds.left + targetBounds.width / 2 - containerBounds.left, 1);
-      expect(position.top).to.be.within(targetBounds.bottom - containerBounds.top, targetBounds.bottom - containerBounds.top + 40);
+      expect(position.left).to.be.within(targetBounds.right - containerBounds.left, targetBounds.right - containerBounds.left + 40);
+      expect(position.top).to.be.closeTo(targetBounds.top + targetBounds.height / 2 - containerBounds.top, 1);
     }));
 
   });

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -318,4 +318,48 @@ describe('<AppendCreatePad>', function() {
 
   });
 
+
+  describe('label editing', function() {
+
+    it('should close while label editing is active', inject(
+      function(appendCreatePad, directEditing, elementRegistry, selection) {
+
+        // given the pad is open for a selected element
+        const task = elementRegistry.get('Task_1');
+
+        selection.select(task);
+
+        expect(appendCreatePad.isOpen()).to.be.true;
+
+        // when direct editing starts
+        directEditing.activate(task);
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+
+    it('should reopen for the same element when label editing ends', inject(
+      function(appendCreatePad, directEditing, elementRegistry, selection) {
+
+        // given direct editing was active for a selected element
+        const task = elementRegistry.get('Task_1');
+
+        selection.select(task);
+
+        directEditing.activate(task);
+
+        expect(appendCreatePad.isOpen()).to.be.false;
+
+        // when direct editing ends
+        directEditing.cancel();
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+  });
+
 });

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
@@ -18,6 +18,10 @@
     <subProcess id="SubProcess_2">
       <task id="Task_RoomInSub" />
     </subProcess>
+    <subProcess id="SubProcess_3">
+      <task id="Task_Blocked" />
+      <task id="Task_Blocker" />
+    </subProcess>
   </process>
   <bpmndi:BPMNDiagram id="BpmnDiagram_1">
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
@@ -51,6 +55,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_RoomInSub_di" bpmnElement="Task_RoomInSub">
         <omgdc:Bounds x="200" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_3_di" bpmnElement="SubProcess_3" isExpanded="true">
+        <omgdc:Bounds x="160" y="1000" width="400" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Blocked_di" bpmnElement="Task_Blocked">
+        <omgdc:Bounds x="200" y="1040" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Blocker_di" bpmnElement="Task_Blocker">
+        <omgdc:Bounds x="320" y="1040" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
@@ -2,6 +2,7 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/bpmn">
   <process id="Process_1" isExecutable="false">
     <task id="Task_NoOutgoing" />
+    <task id="Task_Compensation" isForCompensation="true" />
     <task id="Task_WithBoundary" />
     <boundaryEvent id="BoundaryEvent_NoOutgoing" attachedToRef="Task_WithBoundary" />
     <task id="Task_WithOutgoing">
@@ -14,21 +15,15 @@
     <adHocSubProcess id="AdHocSubProcess_1">
       <task id="Task_InAdHoc" />
     </adHocSubProcess>
-    <subProcess id="SubProcess_1">
-      <task id="Task_NearEdge" />
-    </subProcess>
-    <subProcess id="SubProcess_2">
-      <task id="Task_RoomInSub" />
-    </subProcess>
-    <subProcess id="SubProcess_3">
-      <task id="Task_Blocked" />
-      <task id="Task_Blocker" />
-    </subProcess>
+    <subProcess id="SubProcess_1" />
   </process>
   <bpmndi:BPMNDiagram id="BpmnDiagram_1">
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_NoOutgoing_di" bpmnElement="Task_NoOutgoing">
         <omgdc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_Compensation_di" bpmnElement="Task_Compensation">
+        <omgdc:Bounds x="1000" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_WithBoundary_di" bpmnElement="Task_WithBoundary">
         <omgdc:Bounds x="600" y="80" width="100" height="80" />
@@ -54,24 +49,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
         <omgdc:Bounds x="160" y="600" width="200" height="160" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_NearEdge_di" bpmnElement="Task_NearEdge">
-        <omgdc:Bounds x="240" y="640" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_2_di" bpmnElement="SubProcess_2" isExpanded="true">
-        <omgdc:Bounds x="160" y="800" width="300" height="160" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_RoomInSub_di" bpmnElement="Task_RoomInSub">
-        <omgdc:Bounds x="200" y="840" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="SubProcess_3_di" bpmnElement="SubProcess_3" isExpanded="true">
-        <omgdc:Bounds x="160" y="1000" width="400" height="160" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_Blocked_di" bpmnElement="Task_Blocked">
-        <omgdc:Bounds x="200" y="1040" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Task_Blocker_di" bpmnElement="Task_Blocker">
-        <omgdc:Bounds x="320" y="1040" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
@@ -2,6 +2,8 @@
 <definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/bpmn">
   <process id="Process_1" isExecutable="false">
     <task id="Task_NoOutgoing" />
+    <task id="Task_WithBoundary" />
+    <boundaryEvent id="BoundaryEvent_NoOutgoing" attachedToRef="Task_WithBoundary" />
     <task id="Task_WithOutgoing">
       <outgoing>SequenceFlow_1</outgoing>
     </task>
@@ -27,6 +29,12 @@
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
       <bpmndi:BPMNShape id="Task_NoOutgoing_di" bpmnElement="Task_NoOutgoing">
         <omgdc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_WithBoundary_di" bpmnElement="Task_WithBoundary">
+        <omgdc:Bounds x="600" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BoundaryEvent_NoOutgoing_di" bpmnElement="BoundaryEvent_NoOutgoing">
+        <omgdc:Bounds x="632" y="142" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Task_WithOutgoing_di" bpmnElement="Task_WithOutgoing">
         <omgdc:Bounds x="160" y="220" width="100" height="80" />

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.bpmn
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://bpmn.io/bpmn">
+  <process id="Process_1" isExecutable="false">
+    <task id="Task_NoOutgoing" />
+    <task id="Task_WithOutgoing">
+      <outgoing>SequenceFlow_1</outgoing>
+    </task>
+    <endEvent id="EndEvent_1">
+      <incoming>SequenceFlow_1</incoming>
+    </endEvent>
+    <sequenceFlow id="SequenceFlow_1" sourceRef="Task_WithOutgoing" targetRef="EndEvent_1" />
+    <adHocSubProcess id="AdHocSubProcess_1">
+      <task id="Task_InAdHoc" />
+    </adHocSubProcess>
+    <subProcess id="SubProcess_1">
+      <task id="Task_NearEdge" />
+    </subProcess>
+    <subProcess id="SubProcess_2">
+      <task id="Task_RoomInSub" />
+    </subProcess>
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="Task_NoOutgoing_di" bpmnElement="Task_NoOutgoing">
+        <omgdc:Bounds x="160" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_WithOutgoing_di" bpmnElement="Task_WithOutgoing">
+        <omgdc:Bounds x="160" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1_di" bpmnElement="EndEvent_1">
+        <omgdc:Bounds x="332" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1_di" bpmnElement="SequenceFlow_1">
+        <di:waypoint x="260" y="260" />
+        <di:waypoint x="332" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="AdHocSubProcess_1_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
+        <omgdc:Bounds x="160" y="360" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InAdHoc_di" bpmnElement="Task_InAdHoc">
+        <omgdc:Bounds x="200" y="420" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_1_di" bpmnElement="SubProcess_1" isExpanded="true">
+        <omgdc:Bounds x="160" y="600" width="200" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_NearEdge_di" bpmnElement="Task_NearEdge">
+        <omgdc:Bounds x="240" y="640" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_2_di" bpmnElement="SubProcess_2" isExpanded="true">
+        <omgdc:Bounds x="160" y="800" width="300" height="160" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_RoomInSub_di" bpmnElement="Task_RoomInSub">
+        <omgdc:Bounds x="200" y="840" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -323,4 +323,21 @@ describe('<AppendIndicator>', function() {
     }
   ));
 
+
+  it('should restore a neighbor indicator when the blocking shape is moved to another parent', inject(
+    function(canvas, elementRegistry, modeling) {
+
+      // given a blocked sibling and the blocker inside the same sub-process
+      const blocker = elementRegistry.get('Task_Blocker');
+
+      expect(getIndicator('Task_Blocked', canvas)).not.to.exist;
+
+      // when the blocker is moved out to the root
+      modeling.moveElements([ blocker ], { x: 400, y: -960 }, canvas.getRootElement());
+
+      // then the freed sibling regains its indicator
+      expect(getIndicator('Task_Blocked', canvas)).to.exist;
+    }
+  ));
+
 });

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -68,11 +68,14 @@ describe('<AppendIndicator>', function() {
   ));
 
 
-  it('should not show indicator when the slot would not fit inside a sub-process', inject(
+  // TODO: re-enable once bpmn-js-create-append-anything ships the
+  // `isForCompensation` check in its `shape.append` rule and the dependency is
+  // bumped here (see https://github.com/bpmn-io/bpmn-js-create-append-anything).
+  it.skip('should not show indicator for a compensation activity', inject(
     function(canvas) {
 
-      // then
-      expect(getIndicator('Task_NearEdge', canvas)).not.to.exist;
+      // then appending is not allowed after a compensation activity
+      expect(getIndicator('Task_Compensation', canvas)).not.to.exist;
     }
   ));
 
@@ -82,80 +85,6 @@ describe('<AppendIndicator>', function() {
 
       // then
       expect(getIndicator('SubProcess_1', canvas)).to.exist;
-    }
-  ));
-
-
-  it('should hide a child indicator when the container is resized onto it', inject(
-    function(canvas, elementRegistry, modeling) {
-
-      // given
-      expect(getIndicator('Task_RoomInSub', canvas)).to.exist;
-
-      // when the sub-process right edge is moved onto the child's slot
-      modeling.resizeShape(
-        elementRegistry.get('SubProcess_2'),
-        { x: 160, y: 800, width: 180, height: 160 }
-      );
-
-      // then
-      expect(getIndicator('Task_RoomInSub', canvas)).not.to.exist;
-    }
-  ));
-
-
-  it('should not show indicator when the slot overlaps a neighbor', inject(
-    function(canvas, modeling) {
-
-      // when a shape is created over the indicator's slot
-      modeling.createShape(
-        { type: 'bpmn:Task', width: 100, height: 80 },
-        { x: 320, y: 120 },
-        canvas.getRootElement()
-      );
-
-      // then
-      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
-    }
-  ));
-
-
-  it('should restore a neighbor indicator when the overlapping shape moves away', inject(
-    function(canvas, modeling) {
-
-      // given
-      const overlapping = modeling.createShape(
-        { type: 'bpmn:Task', width: 100, height: 80 },
-        { x: 320, y: 120 },
-        canvas.getRootElement()
-      );
-
-      // when
-      modeling.moveShape(overlapping, { x: 400, y: 0 });
-
-      // then
-      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
-    }
-  ));
-
-
-  it('should restore a neighbor indicator when the overlapping shape is removed', inject(
-    function(canvas, modeling) {
-
-      // given
-      const overlapping = modeling.createShape(
-        { type: 'bpmn:Task', width: 100, height: 80 },
-        { x: 320, y: 120 },
-        canvas.getRootElement()
-      );
-
-      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
-
-      // when
-      modeling.removeShape(overlapping);
-
-      // then
-      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
     }
   ));
 
@@ -333,6 +262,25 @@ describe('<AppendIndicator>', function() {
   ));
 
 
+  it('should hide the indicator when an outgoing flow is added', inject(
+    function(canvas, elementRegistry, modeling) {
+
+      // given
+      const source = elementRegistry.get('Task_NoOutgoing');
+      const target = elementRegistry.get('Task_WithOutgoing');
+
+      // assume the source has an indicator while unconnected
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+
+      // when
+      modeling.connect(source, target);
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+
   it('should restore the indicator when an outgoing flow is removed', inject(
     function(canvas, elementRegistry, modeling) {
 
@@ -375,19 +323,64 @@ describe('<AppendIndicator>', function() {
   ));
 
 
-  it('should restore a neighbor indicator when the blocking shape is moved to another parent', inject(
-    function(canvas, elementRegistry, modeling) {
+  it('should restore both indicators when a delete is undone', inject(
+    function(canvas, elementRegistry, modeling, commandStack) {
 
-      // given a blocked sibling and the blocker inside the same sub-process
-      const blocker = elementRegistry.get('Task_Blocker');
+      // given
+      const source = elementRegistry.get('Task_NoOutgoing');
+      const target = elementRegistry.get('Task_WithOutgoing');
 
-      expect(getIndicator('Task_Blocked', canvas)).not.to.exist;
+      const connection = modeling.connect(source, target);
 
-      // when the blocker is moved out to the root
-      modeling.moveElements([ blocker ], { x: 400, y: -960 }, canvas.getRootElement());
+      modeling.removeConnection(connection);
 
-      // then the freed sibling regains its indicator
-      expect(getIndicator('Task_Blocked', canvas)).to.exist;
+      // assume the source's indicator is back while disconnected
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+
+      // when the removal is undone
+      commandStack.undo();
+
+      // then the source is connected again and its indicator is gone
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should restore both indicators when a reconnect is undone', inject(
+    function(canvas, elementRegistry, modeling, commandStack) {
+
+      // given
+      const connection = elementRegistry.get('SequenceFlow_1');
+      const newSource = elementRegistry.get('Task_NoOutgoing');
+
+      modeling.reconnectStart(connection, newSource, { x: 210, y: 120 });
+
+      // when the reconnect is undone
+      commandStack.undo();
+
+      // then both ends return to their original indicator state
+      expect(getIndicator('Task_WithOutgoing', canvas)).not.to.exist;
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should restore the indicator when an append is undone', inject(
+    function(canvas, elementRegistry, modeling, commandStack) {
+
+      // given
+      const source = elementRegistry.get('Task_NoOutgoing');
+
+      modeling.appendShape(source, { type: 'bpmn:Task' }, { x: 400, y: 120 });
+
+      // assume the source's indicator is gone once it has an outgoing flow
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+
+      // when the append is undone
+      commandStack.undo();
+
+      // then the source has no outgoing flow again and its indicator is back
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
     }
   ));
 

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -1,0 +1,326 @@
+import { expect } from 'chai';
+import { spy, useFakeTimers } from 'sinon';
+
+import {
+  insertCoreStyles,
+  insertBpmnStyles,
+  bootstrapModeler,
+  inject
+} from 'test/TestHelper';
+
+import { query as domQuery } from 'min-dom';
+
+import AppendIndicator from 'lib/bpmn/appendIndicator';
+
+import diagramXML from './AppendIndicator.bpmn';
+
+insertCoreStyles();
+insertBpmnStyles();
+
+
+describe('<AppendIndicator>', function() {
+
+  beforeEach(bootstrapModeler(diagramXML, {
+    additionalModules: [
+      AppendIndicator
+    ]
+  }));
+
+
+  function getIndicator(id, canvas) {
+    return domQuery(`.djs-append-indicator[data-element="${id}"]`, canvas.getContainer());
+  }
+
+
+  it('should show indicator for appendable element without outgoing flow', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should not show indicator when element has outgoing sequence flow', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('Task_WithOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should not show indicator for elements inside an ad-hoc subprocess', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('Task_InAdHoc', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should not show indicator when the slot would not fit inside a sub-process', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('Task_NearEdge', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should show indicator after an expanded sub-process', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('SubProcess_1', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should hide a child indicator when the container is resized onto it', inject(
+    function(canvas, elementRegistry, modeling) {
+
+      // given
+      expect(getIndicator('Task_RoomInSub', canvas)).to.exist;
+
+      // when the sub-process right edge is moved onto the child's slot
+      modeling.resizeShape(
+        elementRegistry.get('SubProcess_2'),
+        { x: 160, y: 800, width: 180, height: 160 }
+      );
+
+      // then
+      expect(getIndicator('Task_RoomInSub', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should not show indicator when the slot overlaps a neighbor', inject(
+    function(canvas, modeling) {
+
+      // when a shape is created over the indicator's slot
+      modeling.createShape(
+        { type: 'bpmn:Task', width: 100, height: 80 },
+        { x: 320, y: 120 },
+        canvas.getRootElement()
+      );
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should restore a neighbor indicator when the overlapping shape moves away', inject(
+    function(canvas, modeling) {
+
+      // given
+      const overlapping = modeling.createShape(
+        { type: 'bpmn:Task', width: 100, height: 80 },
+        { x: 320, y: 120 },
+        canvas.getRootElement()
+      );
+
+      // when
+      modeling.moveShape(overlapping, { x: 400, y: 0 });
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should restore a neighbor indicator when the overlapping shape is removed', inject(
+    function(canvas, modeling) {
+
+      // given
+      const overlapping = modeling.createShape(
+        { type: 'bpmn:Task', width: 100, height: 80 },
+        { x: 320, y: 120 },
+        canvas.getRootElement()
+      );
+
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+
+      // when
+      modeling.removeShape(overlapping);
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should open the append menu on hover', inject(
+    function(appendCreatePad, canvas, elementRegistry) {
+
+      // given
+      const open = spy(appendCreatePad, 'open');
+
+      const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+      // when
+      indicator.dispatchEvent(new MouseEvent('mouseenter'));
+
+      // then
+      expect(open).to.have.been.calledWith(elementRegistry.get('Task_NoOutgoing'));
+    }
+  ));
+
+
+  it('should close the append menu shortly after the pointer leaves', inject(
+    function(appendCreatePad, canvas) {
+
+      // given
+      const clock = useFakeTimers();
+
+      const close = spy(appendCreatePad, 'close');
+
+      const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+      indicator.dispatchEvent(new MouseEvent('mouseenter'));
+
+      const pad = appendCreatePad.getHtml();
+
+      // when
+      pad.dispatchEvent(new MouseEvent('mouseleave'));
+
+      clock.tick(500);
+
+      // then
+      expect(close).to.have.been.called;
+
+      clock.restore();
+    }
+  ));
+
+
+  it('should return to the selected element\'s pad when a hovered pad closes', inject(
+    function(appendCreatePad, canvas, elementRegistry, selection) {
+
+      // given a selected element (its pad opens on selection)
+      const clock = useFakeTimers();
+
+      const selected = elementRegistry.get('AdHocSubProcess_1');
+
+      selection.select(selected);
+
+      // hovering another element's indicator opens that element's pad instead
+      const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+      indicator.dispatchEvent(new MouseEvent('mouseenter'));
+
+      const open = spy(appendCreatePad, 'open');
+
+      const pad = appendCreatePad.getHtml();
+
+      // when the pointer leaves the hovered pad
+      pad.dispatchEvent(new MouseEvent('mouseleave'));
+
+      clock.tick(500);
+
+      // then the selected element's pad is restored
+      expect(open).to.have.been.calledWith(selected);
+
+      clock.restore();
+    }
+  ));
+
+
+  it('should keep other indicators visible while the append menu is open', inject(
+    function(appendCreatePad, canvas, elementRegistry) {
+
+      // given
+      const other = getIndicator('Task_NoOutgoing', canvas);
+
+      // when opening the menu for a different element
+      appendCreatePad.open(elementRegistry.get('AdHocSubProcess_1'));
+
+      // then the other element's indicator stays visible
+      expect(other.style.display).not.to.equal('none');
+    }
+  ));
+
+
+  it('should hide indicators while dragging and restore them afterwards', inject(
+    function(canvas, eventBus) {
+
+      // given
+      const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+      // when a drag is active
+      eventBus.fire('drag.start', {});
+
+      // then the indicator is hidden
+      expect(indicator.style.display).to.equal('none');
+
+      // when the drag settles
+      eventBus.fire('drag.cleanup', {});
+
+      // then it is restored
+      expect(indicator.style.display).not.to.equal('none');
+    }
+  ));
+
+
+  it('should keep the source indicator hidden when a drag starts from its pad', inject(
+    function(appendCreatePad, canvas, eventBus, elementRegistry) {
+
+      // given the pad is open for the element (which hides its indicator)
+      const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+      appendCreatePad.open(elementRegistry.get('Task_NoOutgoing'));
+
+      // when a drag starts from the pad and the pad closes as a result
+      eventBus.fire('drag.start', {});
+
+      appendCreatePad.close();
+
+      // then the indicator does not reappear mid-drag
+      expect(indicator.style.display).to.equal('none');
+    }
+  ));
+
+
+  it('should restore the indicator when an outgoing flow is removed', inject(
+    function(canvas, elementRegistry, modeling) {
+
+      // given
+      const source = elementRegistry.get('Task_NoOutgoing');
+      const target = elementRegistry.get('Task_WithOutgoing');
+
+      const connection = modeling.connect(source, target);
+
+      // assume the indicator is gone while connected
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+
+      // when
+      modeling.removeConnection(connection);
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should update both indicators when a flow\'s source is reconnected', inject(
+    function(canvas, elementRegistry, modeling) {
+
+      // given
+      const connection = elementRegistry.get('SequenceFlow_1');
+      const newSource = elementRegistry.get('Task_NoOutgoing');
+
+      // assume the old source has no indicator and the new source has one
+      expect(getIndicator('Task_WithOutgoing', canvas)).not.to.exist;
+      expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
+
+      // when
+      modeling.reconnectStart(connection, newSource, { x: 210, y: 120 });
+
+      // then
+      expect(getIndicator('Task_WithOutgoing', canvas)).to.exist;
+      expect(getIndicator('Task_NoOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+});

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -50,6 +50,15 @@ describe('<AppendIndicator>', function() {
   ));
 
 
+  it('should show indicator for a boundary event without outgoing flow', inject(
+    function(canvas) {
+
+      // then
+      expect(getIndicator('BoundaryEvent_NoOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
   it('should not show indicator for elements inside an ad-hoc subprocess', inject(
     function(canvas) {
 
@@ -278,6 +287,48 @@ describe('<AppendIndicator>', function() {
 
       // then the indicator does not reappear mid-drag
       expect(indicator.style.display).to.equal('none');
+    }
+  ));
+
+
+  it('should hide indicators while a label is edited and restore them afterwards', inject(
+    function(canvas, directEditing, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_NoOutgoing');
+
+      // when a label is edited directly
+      directEditing.activate(task);
+
+      // then the indicator is hidden so it does not overlap the edit box
+      expect(getIndicator('Task_NoOutgoing', canvas).style.display).to.equal('none');
+
+      // when editing ends
+      directEditing.cancel();
+
+      // then it is restored
+      expect(getIndicator('Task_NoOutgoing', canvas).style.display).not.to.equal('none');
+    }
+  ));
+
+  it('should keep indicators hidden when a drag-append hands over to editing', inject(
+    function(canvas, directEditing, elementRegistry, eventBus) {
+
+      // given a drag-append: editing activates before the drag is cleaned up
+      const task = elementRegistry.get('Task_NoOutgoing');
+
+      eventBus.fire('drag.start', {});
+      directEditing.activate(task);
+      eventBus.fire('drag.cleanup', {});
+
+      // then indicators stay hidden while editing continues
+      expect(getIndicator('Task_NoOutgoing', canvas).style.display).to.equal('none');
+
+      // when editing ends
+      directEditing.cancel();
+
+      // then they are restored
+      expect(getIndicator('Task_NoOutgoing', canvas).style.display).not.to.equal('none');
     }
   ));
 

--- a/test/spec/bpmn/contextPad/ImprovedContextPad.spec.js
+++ b/test/spec/bpmn/contextPad/ImprovedContextPad.spec.js
@@ -127,4 +127,48 @@ describe('<ImprovedContextPad>', function() {
 
   });
 
+
+  describe('label editing', function() {
+
+    it('should hide the context pad while label editing is active', inject(
+      function(contextPad, directEditing, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+
+        contextPad.open(element);
+
+        expect(contextPad.isShown()).to.be.true;
+
+        // when
+        directEditing.activate(element);
+
+        // then
+        expect(contextPad.isShown()).to.be.false;
+      }
+    ));
+
+
+    it('should restore the context pad when label editing ends', inject(
+      function(contextPad, directEditing, elementRegistry) {
+
+        // given
+        const element = elementRegistry.get('Task_1');
+
+        contextPad.open(element);
+
+        directEditing.activate(element);
+
+        expect(contextPad.isShown()).to.be.false;
+
+        // when
+        directEditing.cancel();
+
+        // then
+        expect(contextPad.isShown()).to.be.true;
+      }
+    ));
+
+  });
+
 });


### PR DESCRIPTION
### Proposed Changes

Adds a persistent grey `+` next to elements that can be appended to but have no outgoing sequence flow, nudging the user to finish the path. Hovering it opens the append pad.

- Shows the `+` next to an element only when appending after it is allowed and it has no outgoing sequence flow.
- Hovering opens the append menu; the `+` hides while the menu is open.
- Scales with zoom and hides when zoomed too far out.
- Not shown for elements inside an ad-hoc sub-process, where completing the path is optional.
- Shown after a sub-process (expanded or ad-hoc), like any other element.
- Stays in sync as elements are added, moved, resized, or removed, and as sequence flows are connected or deleted.


https://github.com/user-attachments/assets/72982c93-e79e-4312-b048-62c4edbc50ee



**Try it**:

`npx @bpmn-io/sr camunda/improved-canvas#intent-driven-pads-phase-2`

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
