### PR TITLE
fix: fix `A` shortcut for append on participant shows empty append menu

### DIFF
--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -34,7 +34,7 @@ export default class AppendCreatePad extends CreatePad {
       return false;
     }
 
-    if (this._rules.allowed('shape.append', { element: target })) {
+    if (this.canAppend(target)) {
       return true;
     }
 
@@ -44,10 +44,14 @@ export default class AppendCreatePad extends CreatePad {
     return !!entries['connect'];
   }
 
+  canAppend(target) {
+    return this._rules.allowed('shape.append', { element: target });
+  }
+
   getEntries(target) {
     const entries = this._contextPadProvider.getContextPadEntries(target);
 
-    const canAppend = this._rules.allowed('shape.append', { element: target });
+    const canAppend = this.canAppend(target);
 
     return {
 

--- a/lib/bpmn/appendCreatePad/AppendEditorActions.js
+++ b/lib/bpmn/appendCreatePad/AppendEditorActions.js
@@ -40,7 +40,7 @@ export default class AppendEditorActions {
       appendCreatePad: (event) => {
         const selected = this._selection.get();
 
-        if (appendCreatePad.isOpen()) {
+        if (appendCreatePad.isOpen() && appendCreatePad.canAppend(selected[ 0 ])) {
           const html = appendCreatePad.getHtml();
 
           const bBox = html.getBoundingClientRect();

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -101,6 +101,36 @@ describe('<AppendCreatePad>', function() {
   });
 
 
+  describe('#canAppend', function() {
+
+    it('should return true if append allowed', inject(function(appendCreatePad, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const canAppend = appendCreatePad.canAppend(task);
+
+      // then
+      expect(canAppend).to.be.true;
+    }));
+
+
+    it('should return false for a connect-only element', inject(function(appendCreatePad, elementRegistry) {
+
+      // given
+      const endEvent = elementRegistry.get('EndEvent_1');
+
+      // when
+      const canAppend = appendCreatePad.canAppend(endEvent);
+
+      // then
+      expect(canAppend).to.be.false;
+    }));
+
+  });
+
+
   describe('#getEntries', function() {
 
     it('should get append entries (task)', inject(function(appendCreatePad, elementRegistry) {

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -195,6 +195,35 @@ describe('<AppendCreatePad>', function() {
   });
 
 
+  describe('editor action', function() {
+
+    it('should trigger create entry if append is not allowed', inject(
+      function(appendCreatePad, editorActions, elementRegistry, palette, popupMenu, selection) {
+
+        // given
+        const endEvent = elementRegistry.get('EndEvent_1');
+
+        const triggerEntry = sinon.spy(palette, 'triggerEntry');
+        const open = sinon.spy(popupMenu, 'open');
+
+        selection.select(endEvent);
+
+        expect(appendCreatePad.isOpen()).to.be.true;
+
+        // when
+        editorActions.trigger('appendCreatePad', {});
+
+        // then
+        expect(triggerEntry).to.have.been.calledOnce;
+        expect(triggerEntry.firstCall.args[ 0 ]).to.equal('create');
+        expect(triggerEntry.firstCall.args[ 1 ]).to.equal('click');
+        expect(open.getCalls().filter(({ args }) => args[ 1 ] === 'bpmn-append')).to.have.length(0);
+      }
+    ));
+
+  });
+
+
   describe('#getPosition', function() {
 
     it('should return position for task', inject(function(appendCreatePad, canvas, elementRegistry) {


### PR DESCRIPTION
### Proposed Changes

Fix a regression introduced by https://github.com/camunda/improved-canvas/pull/82 -  `A` shortcut for append on participant shows empty append menu instead of create element menu.


**Before fix:**

https://github.com/user-attachments/assets/94fc0982-8f86-4257-9469-57b4602906da


**After fix:**

https://github.com/user-attachments/assets/4e963d8f-8633-4000-b2a8-76869e2b1058




### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
