### PR TITLE
feat: hide create pad and append indicator while canvas is locked

### DIFF
--- a/lib/bpmn/appendCanvasLock/AppendCanvasLock.js
+++ b/lib/bpmn/appendCanvasLock/AppendCanvasLock.js
@@ -1,0 +1,64 @@
+/**
+ * @typedef {import('diagram-js/lib/core/EventBus').default} EventBus
+ * @typedef {import('didi').Injector} Injector
+ */
+
+/**
+ * Integrates the append create pad and append indicator with
+ * diagram-js-canvas-lock.
+ *
+ * The features stay lock-agnostic: the create pad fires `createPad.open.allowed`
+ * (diagram-js `*.allowed` convention) and this module vetoes it while the canvas
+ * is locked. Because a veto only gates new interactions, this module also tears
+ * down the already-open append UI on `canvasLock.changed` and restores it on
+ * unlock, mirroring how diagram-js-canvas-lock closes open UI on lock.
+ *
+ * No-op when diagram-js-canvas-lock is not present.
+ *
+ * @param {EventBus} eventBus
+ * @param {Injector} injector
+ */
+export default function AppendCanvasLock(eventBus, injector) {
+  const canvasLock = injector.get('canvasLock', false);
+
+  if (!canvasLock) {
+    return;
+  }
+
+  const appendCreatePad = injector.get('appendCreatePad', false);
+  const appendIndicator = injector.get('appendIndicator', false);
+  const selection = injector.get('selection', false);
+
+  // veto opening the create pad while the canvas is locked
+  eventBus.on('createPad.open.allowed', function() {
+    if (canvasLock.isLocked()) {
+      return false;
+    }
+  });
+
+  // close open append UI on lock, restore it on unlock
+  eventBus.on('canvasLock.changed', function({ locked }) {
+    if (appendIndicator) {
+      appendIndicator.setEnabled(!locked);
+    }
+
+    if (!appendCreatePad) {
+      return;
+    }
+
+    if (locked) {
+      appendCreatePad.close();
+
+      return;
+    }
+
+    // reopen the pad for a single selection once unlocked
+    const selected = selection && selection.get();
+
+    if (selected && selected.length === 1) {
+      appendCreatePad.open(selected[0]);
+    }
+  });
+}
+
+AppendCanvasLock.$inject = [ 'eventBus', 'injector' ];

--- a/lib/bpmn/appendCanvasLock/index.js
+++ b/lib/bpmn/appendCanvasLock/index.js
@@ -1,0 +1,13 @@
+import AppendCanvasLock from './AppendCanvasLock';
+
+import AppendCreatePadModule from '../appendCreatePad';
+import AppendIndicatorModule from '../appendIndicator';
+
+export default {
+  __depends__: [
+    AppendCreatePadModule,
+    AppendIndicatorModule
+  ],
+  __init__: [ 'appendCanvasLock' ],
+  appendCanvasLock: [ 'type', AppendCanvasLock ]
+};

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -34,10 +34,9 @@ export default class AppendIndicator {
 
     this._closeTimeout = null;
 
-    // indicators hide during a drag or direct edit
-    this._dragging = false;
-    this._editing = false;
-    this._disabled = false;
+    // reasons the indicators are disabled; they are visible when there are none
+    // (e.g. while dragging, direct editing or disabled externally by a lock)
+    this._disabledBy = new Set();
 
     // refresh all indicators on load
     eventBus.on('import.done', () => this._refreshAll());
@@ -69,10 +68,10 @@ export default class AppendIndicator {
     });
 
     // hide indicators during a drag or direct edit, then restore them
-    eventBus.on('drag.start', () => this._setDisabled({ dragging: true }));
-    eventBus.on('drag.cleanup', () => this._setDisabled({ dragging: false }));
-    eventBus.on('directEditing.activate', () => this._setDisabled({ editing: true }));
-    eventBus.on('directEditing.deactivate', () => this._setDisabled({ editing: false }));
+    eventBus.on('drag.start', () => this._setDisabledBy('dragging', true));
+    eventBus.on('drag.cleanup', () => this._setDisabledBy('dragging', false));
+    eventBus.on('directEditing.activate', () => this._setDisabledBy('editing', true));
+    eventBus.on('directEditing.deactivate', () => this._setDisabledBy('editing', false));
   }
 
   _canAdd(element) {
@@ -176,18 +175,28 @@ export default class AppendIndicator {
     // never reveal an indicator while disabled
     this._setOverlaysVisibility(
       this._overlays.get({ element, type: OVERLAY_TYPE }),
-      visible && !this._disabled
+      visible && !this._isDisabled()
     );
   }
 
-  // hide or restore all indicators; they return only when neither dragging nor editing
-  _setDisabled({ dragging = this._dragging, editing = this._editing }) {
-    this._dragging = dragging;
-    this._editing = editing;
+  // enable or disable the indicators externally (e.g. while the canvas is locked)
+  setEnabled(enabled) {
+    this._setDisabledBy('external', !enabled);
+  }
 
-    this._disabled = dragging || editing;
+  // add or clear a reason the indicators are disabled, then update their visibility
+  _setDisabledBy(reason, disabled) {
+    if (disabled) {
+      this._disabledBy.add(reason);
+    } else {
+      this._disabledBy.delete(reason);
+    }
 
-    this._setAllVisible(!this._disabled);
+    this._setAllVisible(!this._isDisabled());
+  }
+
+  _isDisabled() {
+    return this._disabledBy.size > 0;
   }
 
   _setAllVisible(visible) {

--- a/lib/bpmn/index.js
+++ b/lib/bpmn/index.js
@@ -5,6 +5,7 @@ import resourceLinking from './resourceLinking';
 import showComments from './showComments';
 import appendCreatePad from './appendCreatePad';
 import appendIndicator from './appendIndicator';
+import appendCanvasLock from './appendCanvasLock';
 import improvedPalette from './palette';
 
 export default {
@@ -14,6 +15,7 @@ export default {
     improvedPopupMenu,
     appendCreatePad,
     appendIndicator,
+    appendCanvasLock,
     resourceLinking,
     showComments,
     improvedPalette

--- a/lib/common/createPad/CreatePad.js
+++ b/lib/common/createPad/CreatePad.js
@@ -95,6 +95,10 @@ export default class CreatePad {
       return;
     }
 
+    if (this._eventBus.fire('createPad.open.allowed', { target }) === false) {
+      return;
+    }
+
     this._open(target);
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@babel/plugin-transform-react-jsx": "^7.28.6",
+        "@bpmn-io/diagram-js-canvas-lock": "^0.1.0",
         "@bpmn-io/properties-panel": "^3.47.0",
         "@rollup/plugin-alias": "^6.0.0",
         "@rollup/plugin-babel": "^7.1.0",
@@ -397,6 +398,22 @@
       "peerDependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/@bpmn-io/diagram-js-canvas-lock": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-canvas-lock/-/diagram-js-canvas-lock-0.1.0.tgz",
+      "integrity": "sha512-97sF+juqMeet4XdbU9lWUM8jWXLm7pNLBsDIcWz7+sGPqoZwAB8bQusOIMQiAPU9YGgliwj3b0o0kLP5h2jk1g==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "diagram-js": ">= 15.16.0",
+        "diagram-js-direct-editing": ">= 3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "diagram-js-direct-editing": {
+          "optional": true
+        }
       }
     },
     "node_modules/@bpmn-io/diagram-js-ui": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "devDependencies": {
     "@babel/plugin-transform-react-jsx": "^7.28.6",
+    "@bpmn-io/diagram-js-canvas-lock": "^0.1.0",
     "@bpmn-io/properties-panel": "^3.47.0",
     "@rollup/plugin-alias": "^6.0.0",
     "@rollup/plugin-babel": "^7.1.0",

--- a/test/spec/bpmn/BPMNImprovedCanvas.spec.js
+++ b/test/spec/bpmn/BPMNImprovedCanvas.spec.js
@@ -7,6 +7,7 @@ import {
   setBpmnJS,
   insertCoreStyles,
   insertBpmnStyles,
+  insertCSS,
   enableLogging
 } from 'test/TestHelper';
 
@@ -33,6 +34,8 @@ import ZeebeModdle from 'zeebe-bpmn-moddle/resources/zeebe';
 
 import BpmnJSColorPicker from 'bpmn-js-color-picker';
 
+import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
+
 import { BpmnImprovedCanvasModule } from 'lib/';
 
 
@@ -40,6 +43,10 @@ const singleStart = window.__env__ && window.__env__.SINGLE_START === 'bpmn';
 
 insertCoreStyles();
 insertBpmnStyles();
+insertCSS(
+  'canvas-lock.css',
+  require('@bpmn-io/diagram-js-canvas-lock/assets/canvas-lock.css').default
+);
 
 describe('<Example>', function() {
 
@@ -72,6 +79,7 @@ describe('<Example>', function() {
         ZeebePropertiesProviderModule,
         BpmnImprovedCanvasModule,
         BpmnJSColorPicker,
+        CanvasLockModule,
         CloudElementTemplatesPropertiesProviderModule
       ],
       moddleExtensions = {
@@ -133,6 +141,22 @@ describe('<Example>', function() {
     expect(result.error).not.to.exist;
 
     expect(result.modeler.get('canvas').getContainer().classList.contains('bio-improved-canvas')).to.be.true;
+
+    // add a button to toggle the canvas lock for interactive play
+    if (singleStart) {
+      const canvasLock = result.modeler.get('canvasLock');
+
+      const button = document.createElement('button');
+
+      button.textContent = 'Toggle canvas lock';
+      button.style.cssText = 'position: absolute; top: 10px; right: 10px; z-index: 100;';
+
+      button.addEventListener('click', () => {
+        canvasLock.isLocked() ? canvasLock.unlock() : canvasLock.lock();
+      });
+
+      modelerContainer.appendChild(button);
+    }
   });
 
 

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -4,13 +4,18 @@ import { spy } from 'sinon';
 import {
   insertCoreStyles,
   insertBpmnStyles,
+  insertCSS,
   bootstrapModeler,
   inject
 } from 'test/TestHelper';
 
+import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
+
 import AppendCreatePad from 'lib/bpmn/appendCreatePad';
 
 import { PAD_GAP } from 'lib/common/constants';
+
+import AppendCanvasLockModule from 'lib/bpmn/appendCanvasLock';
 
 import diagramXML from './AppendCreatePad.bpmn';
 
@@ -25,6 +30,76 @@ describe('<AppendCreatePad>', function() {
       AppendCreatePad
     ]
   }));
+
+
+  describe('integration with diagram-js-canvas-lock', function() {
+
+    insertCSS(
+      'canvas-lock.css',
+      require('@bpmn-io/diagram-js-canvas-lock/assets/canvas-lock.css').default
+    );
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      additionalModules: [
+        AppendCanvasLockModule,
+        CanvasLockModule
+      ]
+    }));
+
+
+    it('should close the pad when the canvas is locked', inject(
+      function(appendCreatePad, canvasLock, elementRegistry) {
+
+        // given
+        appendCreatePad.open(elementRegistry.get('Task_1'));
+
+        // assume
+        expect(appendCreatePad.isOpen()).to.be.true;
+
+        // when
+        canvasLock.lock();
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+
+    it('should not open the pad while the canvas is locked', inject(
+      function(appendCreatePad, canvasLock, elementRegistry) {
+
+        // given
+        canvasLock.lock();
+
+        // when
+        appendCreatePad.open(elementRegistry.get('Task_1'));
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+
+    it('should reopen the pad for the selection after unlock', inject(
+      function(appendCreatePad, canvasLock, elementRegistry, selection) {
+
+        // given
+        selection.select(elementRegistry.get('Task_1'));
+
+        canvasLock.lock();
+
+        // assume
+        expect(appendCreatePad.isOpen()).to.be.false;
+
+        // when
+        canvasLock.unlock();
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+  });
 
 
   it('should have custom class name', inject(function(appendCreatePad, canvas, elementRegistry) {

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -4,13 +4,18 @@ import { spy, useFakeTimers } from 'sinon';
 import {
   insertCoreStyles,
   insertBpmnStyles,
+  insertCSS,
   bootstrapModeler,
   inject
 } from 'test/TestHelper';
 
 import { query as domQuery } from 'min-dom';
 
+import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
+
 import AppendIndicator from 'lib/bpmn/appendIndicator';
+
+import AppendCanvasLockModule from 'lib/bpmn/appendCanvasLock';
 
 import diagramXML from './AppendIndicator.bpmn';
 
@@ -123,6 +128,58 @@ describe('<AppendIndicator>', function() {
       expect(open).to.have.been.calledWith(elementRegistry.get('Task_NoOutgoing'));
     }
   ));
+
+
+  describe('integration with diagram-js-canvas-lock', function() {
+
+    insertCSS(
+      'canvas-lock.css',
+      require('@bpmn-io/diagram-js-canvas-lock/assets/canvas-lock.css').default
+    );
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      additionalModules: [
+        AppendCanvasLockModule,
+        CanvasLockModule
+      ]
+    }));
+
+
+    it('should hide the indicator while the canvas is locked', inject(
+      function(canvas, canvasLock) {
+
+        // given
+        const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+        // assume
+        expect(getComputedStyle(indicator).display).not.to.equal('none');
+
+        // when
+        canvasLock.lock();
+
+        // then
+        expect(getComputedStyle(indicator).display).to.equal('none');
+      }
+    ));
+
+
+    it('should show the indicator again after the canvas is unlocked', inject(
+      function(canvas, canvasLock) {
+
+        // given
+        const indicator = getIndicator('Task_NoOutgoing', canvas);
+
+        canvasLock.lock();
+
+        // when
+        canvasLock.unlock();
+
+        // then
+        expect(getComputedStyle(indicator).display).not.to.equal('none');
+      }
+    ));
+
+  });
 
 
   it('should close the append menu shortly after the pointer leaves', inject(


### PR DESCRIPTION
## Proposed Changes

<img width="1920" height="911" alt="chrome_8JtroygwtC" src="https://github.com/user-attachments/assets/e87d522c-4c65-41ff-963c-86e8600bea86" />

Integrates the append create pad and append indicator with [`@bpmn-io/diagram-js-canvas-lock`](https://github.com/bpmn-io/diagram-js-canvas-lock).

When the canvas is locked, the integration:

* vetoes new create-pad openings through `createPad.open.allowed`;
* closes an already open append create pad;
* hides append indicators; and
* restores the append create pad for a single selected element, plus append indicators, once the canvas is unlocked.

The integration is a no-op when `diagram-js-canvas-lock` is not registered. Existing create-pad behavior remains unchanged for consumers that do not use canvas locking.

Related to https://github.com/camunda/camunda-modeler/issues/5916

## Steps to Try Out

1. Run `npm start`.
2. Open the BPMN example and select an element to open its append create pad.
3. Click **Toggle canvas lock**.
4. Verify that the append create pad closes and append indicators disappear.
5. While locked, select an element and verify that the append create pad does not open.
6. Unlock the canvas and verify that the append create pad reopens for the selected element and append indicators return.

## Checklist

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)