### PR TITLE
fix: display append pad entry title as tooltip

### DIFF
--- a/assets/base.css
+++ b/assets/base.css
@@ -11,3 +11,23 @@
   --blue-60: #0f62fe;
   --blue-70: #0043ce;
 }
+
+/* shared tooltip look for the improved-canvas pads (context pad + create pad). */
+.bio-improved-canvas .bio-properties-panel-tooltip-wrapper {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  width: fit-content;
+  text-decoration: none;
+}
+
+.bio-improved-canvas .bio-properties-panel-tooltip {
+  position: absolute;
+}
+
+.bio-improved-canvas .bio-properties-panel-tooltip-content {
+  font-size: 12px;
+  padding: 9px 12px;
+  border-radius: 4px;
+  width: max-content;
+}

--- a/assets/context-pad.css
+++ b/assets/context-pad.css
@@ -78,22 +78,6 @@
   font-size: 18px;
 }
 
-.bio-improved-canvas .djs-context-pad .bio-properties-panel-tooltip-wrapper {
-  position: relative;
-  text-decoration: none;
-}
-
-.bio-improved-canvas .djs-context-pad .bio-properties-panel-tooltip {
-  position: absolute;
-}
-
-.bio-improved-canvas .djs-context-pad .bio-properties-panel-tooltip-content {
-  font-size: 12px;
-  padding: 9px 12px;
-  border-radius: 4px;
-  width: max-content;
-}
-
 .bio-improved-canvas .djs-context-pad .entry:last-child {
   margin-right: 0;
 }

--- a/assets/create-pad.css
+++ b/assets/create-pad.css
@@ -43,7 +43,6 @@
   .djs-create-pad-entries {
     display: none;
     flex-direction: row;
-    overflow: hidden;
     padding: 4px;
     border-radius: 4px;
     background-color: white;
@@ -123,4 +122,8 @@
   &:hover {
     background-color: var(--gray-40);
   }
+}
+
+.bio-improved-canvas .djs-create-pad .djs-create-pad-tooltip {
+  display: contents;
 }

--- a/lib/common/createPad/CreatePad.js
+++ b/lib/common/createPad/CreatePad.js
@@ -25,7 +25,18 @@ import { insertCSS } from '../../util';
 import baseCSS from '../../../assets/base.css';
 import createPadCSS from '../../../assets/create-pad.css';
 
+import { domify } from 'min-dom';
+
+import { TooltipEntry } from '@bpmn-io/properties-panel';
+
+import { render } from '@bpmn-io/properties-panel/preact';
+
+import { html as htm } from 'htm/preact';
+
 const ENTRY_MOUSE_ENTER_TIMEOUT_MS = 300;
+
+// centered just above the entry, matching the context pad tooltip offset
+const TOOLTIP_POSITION = 'left: 50%; bottom: 100%; transform: translateX(-50%);';
 
 export default class CreatePad {
   constructor(canvas, eventBus, className) {
@@ -223,64 +234,113 @@ export default class CreatePad {
     entriesHtml.classList.add('djs-create-pad-entries');
 
     for (const id in entries) {
-      entriesHtml.appendChild(this._getEntryHtml(target, entries[ id ]));
+      entriesHtml.appendChild(this._getEntryHtml(id, entries[ id ]));
     }
+
+    this._bindEntryListeners(entriesHtml, entries, target);
 
     return entriesHtml;
   }
 
-  _getEntryHtml(target, entry) {
+  _getEntryHtml(id, entry) {
     const html = document.createElement('div');
 
     html.classList.add('djs-create-pad-entry');
+    html.setAttribute('data-entry-id', id);
 
     if (entry.className) {
       html.classList.add(entry.className);
-    }
-
-    if (entry.title) {
-      html.setAttribute('title', entry.title);
     }
 
     if (entry.html) {
       html.innerHTML = entry.html;
     }
 
-    const { action } = entry;
-
-    if (action) {
-      if (action.click) {
-        html.addEventListener('click', (event) => action.click(event, target));
-      }
-
-      if (action.dragstart) {
-        html.setAttribute('draggable', true);
-
-        html.addEventListener('dragstart', (event) => action.dragstart(event, target));
-      }
-
-      if (action.hover) {
-        html.addEventListener('mouseenter', (event) => {
-          this._entryMouseEnterTimeout = setTimeout(() => {
-            this._entryMouseLeaveCallback = action.hover(event, target);
-          }, ENTRY_MOUSE_ENTER_TIMEOUT_MS);
-        });
-
-        html.addEventListener('mouseleave', (event) => {
-          clearTimeout(this._entryMouseEnterTimeout);
-
-          this._entryMouseEnterTimeout = null;
-
-          if (this._entryMouseLeaveCallback) {
-            this._entryMouseLeaveCallback(event, target);
-
-            this._entryMouseLeaveCallback = null;
-          }
-        });
-      }
+    if (entry.action && entry.action.dragstart) {
+      html.setAttribute('draggable', true);
     }
 
-    return html;
+    if (!entry.title) {
+      return html;
+    }
+
+    return this._wrapWithTooltip(html, entry.title);
+  }
+
+  _wrapWithTooltip(entry, title) {
+    entry.setAttribute('aria-label', title);
+    entry.setAttribute('role', 'button');
+
+    const wrapper = domify('<div class="djs-create-pad-tooltip"></div>');
+
+    render(htm`
+      <${TooltipEntry} value=${title} direction="top" position=${TOOLTIP_POSITION}>
+        <div dangerouslySetInnerHTML=${{ __html: entry.outerHTML }} />
+      </${TooltipEntry}>
+    `, wrapper);
+
+    return wrapper;
+  }
+
+  _bindEntryListeners(container, entries, target) {
+    const actionFor = (event, name) => {
+      const element = event.target.closest('.djs-create-pad-entry');
+
+      if (!element || !container.contains(element)) {
+        return null;
+      }
+
+      const entry = entries[ element.getAttribute('data-entry-id') ];
+      const action = entry && entry.action && entry.action[ name ];
+
+      return action ? { element, action } : null;
+    };
+
+    // ignore moves within the same entry; only real enter/leave should count
+    const isInternalMove = (found, event) =>
+      event.relatedTarget && found.element.contains(event.relatedTarget);
+
+    container.addEventListener('click', (event) => {
+      const found = actionFor(event, 'click');
+
+      found && found.action(event, target);
+    });
+
+    container.addEventListener('dragstart', (event) => {
+      const found = actionFor(event, 'dragstart');
+
+      found && found.action(event, target);
+    });
+
+    container.addEventListener('mouseover', (event) => {
+      const found = actionFor(event, 'hover');
+
+      if (!found || isInternalMove(found, event)) {
+        return;
+      }
+
+      this._entryMouseEnterTimeout = setTimeout(() => {
+        this._entryMouseLeaveCallback = found.action(event, target);
+      }, ENTRY_MOUSE_ENTER_TIMEOUT_MS);
+    });
+
+    container.addEventListener('mouseout', (event) => {
+      const found = actionFor(event, 'hover');
+
+      if (!found || isInternalMove(found, event)) {
+        return;
+      }
+
+      clearTimeout(this._entryMouseEnterTimeout);
+
+      this._entryMouseEnterTimeout = null;
+
+      if (this._entryMouseLeaveCallback) {
+        this._entryMouseLeaveCallback(event, target);
+
+        this._entryMouseLeaveCallback = null;
+      }
+    });
   }
 
   _updatePosition() {

--- a/test/spec/common/createPad/CreatePad.spec.js
+++ b/test/spec/common/createPad/CreatePad.spec.js
@@ -305,7 +305,7 @@ describe('<CreatePad>', function() {
     }));
 
 
-    it('should add title', inject(function(customCreatePad, elementRegistry) {
+    it('should render the title as a tooltip', inject(function(customCreatePad, elementRegistry) {
 
       // given
       const task = elementRegistry.get('Task_1');
@@ -321,8 +321,14 @@ describe('<CreatePad>', function() {
       customCreatePad.open(task);
 
       // then
-      expect(domQuery('.baz', customCreatePad.getHtml())).to.exist;
-      expect(domQuery('.baz', customCreatePad.getHtml()).getAttribute('title')).to.equal('Baz');
+      const entry = domQuery('.baz', customCreatePad.getHtml());
+
+      expect(entry).to.exist;
+
+      // the native title is replaced by the accessible tooltip
+      expect(entry.getAttribute('title')).not.to.exist;
+      expect(entry.getAttribute('aria-label')).to.equal('Baz');
+      expect(domQuery('.bio-properties-panel-tooltip-wrapper', customCreatePad.getHtml())).to.exist;
     }));
 
 
@@ -375,6 +381,36 @@ describe('<CreatePad>', function() {
       }));
 
 
+      it('should trigger action on a tooltip-wrapped entry', inject(function(customCreatePad, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const clickSpy = spy();
+
+        // a title makes the entry render inside a tooltip (cloning the entry)
+        stub(customCreatePad, 'getEntries').callsFake(() => ({
+          baz: {
+            className: 'baz',
+            title: 'Baz',
+            action: {
+              click: clickSpy
+            }
+          }
+        }));
+
+        // when
+        customCreatePad.open(task);
+
+        // then
+        const entry = domQuery('.baz', customCreatePad.getHtml());
+
+        entry.click();
+
+        expect(clickSpy).to.have.been.called;
+      }));
+
+
       it('should add dragstart action', inject(function(customCreatePad, elementRegistry) {
 
         // given
@@ -397,7 +433,7 @@ describe('<CreatePad>', function() {
         // then
         const entry = domQuery('.baz', customCreatePad.getHtml());
 
-        entry.dispatchEvent(new DragEvent('dragstart'));
+        dragstart(entry);
 
         expect(dragstartSpy).to.have.been.called;
       }));
@@ -416,7 +452,7 @@ describe('<CreatePad>', function() {
         });
 
 
-        it('should handle mouseenter and mouseleave', inject(function(customCreatePad, elementRegistry) {
+        it('should handle hover in and out', inject(function(customCreatePad, elementRegistry) {
 
           // given
           const task = elementRegistry.get('Task_1');
@@ -443,19 +479,19 @@ describe('<CreatePad>', function() {
           // then
           const entry = domQuery('.baz', customCreatePad.getHtml());
 
-          entry.dispatchEvent(new MouseEvent('mouseenter'));
+          mouseover(entry);
 
           clock.tick(500);
 
           expect(mouseenterSpy).to.have.been.called;
 
-          entry.dispatchEvent(new MouseEvent('mouseleave'));
+          mouseout(entry);
 
           expect(mouseleaveSpy).to.have.been.called;
         }));
 
 
-        it('should not handle mouseenter', inject(function(customCreatePad, elementRegistry) {
+        it('should not trigger hover before the delay', inject(function(customCreatePad, elementRegistry) {
 
           // given
           const task = elementRegistry.get('Task_1');
@@ -482,18 +518,18 @@ describe('<CreatePad>', function() {
           // then
           const entry = domQuery('.baz', customCreatePad.getHtml());
 
-          entry.dispatchEvent(new MouseEvent('mouseenter'));
+          mouseover(entry);
 
           clock.tick(100);
 
-          entry.dispatchEvent(new MouseEvent('mouseleave'));
+          mouseout(entry);
 
           expect(mouseenterSpy).not.to.have.been.called;
           expect(mouseleaveSpy).not.to.have.been.called;
         }));
 
 
-        it('should always handle mouseleave after mouseenter', inject(function(customCreatePad, elementRegistry) {
+        it('should handle leave on pad close', inject(function(customCreatePad, elementRegistry) {
 
           // given
           const task = elementRegistry.get('Task_1');
@@ -520,7 +556,7 @@ describe('<CreatePad>', function() {
           // then
           const entry = domQuery('.baz', customCreatePad.getHtml());
 
-          entry.dispatchEvent(new MouseEvent('mouseenter'));
+          mouseover(entry);
 
           clock.tick(500);
 
@@ -529,6 +565,86 @@ describe('<CreatePad>', function() {
           customCreatePad.close();
 
           expect(mouseleaveSpy).to.have.been.called;
+        }));
+
+
+        it('should ignore hover on a non-entry target', inject(function(customCreatePad, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          const mouseenterSpy = spy(),
+                mouseleaveSpy = spy();
+
+          stub(customCreatePad, 'getEntries').callsFake(() => ({
+            baz: {
+              className: 'baz',
+              action: {
+                hover: () => {
+                  mouseenterSpy();
+
+                  return mouseleaveSpy;
+                }
+              }
+            }
+          }));
+
+          customCreatePad.open(task);
+
+          const entries = domQuery('.djs-create-pad-entries', customCreatePad.getHtml());
+
+          // when hovering the entries container rather than an entry
+          mouseover(entries);
+
+          clock.tick(500);
+
+          mouseout(entries);
+
+          // then
+          expect(mouseenterSpy).not.to.have.been.called;
+          expect(mouseleaveSpy).not.to.have.been.called;
+        }));
+
+
+        it('should ignore hover that stays within the same entry', inject(function(customCreatePad, elementRegistry) {
+
+          // given
+          const task = elementRegistry.get('Task_1');
+
+          const mouseenterSpy = spy(),
+                mouseleaveSpy = spy();
+
+          stub(customCreatePad, 'getEntries').callsFake(() => ({
+            baz: {
+              className: 'baz',
+              action: {
+                hover: () => {
+                  mouseenterSpy();
+
+                  return mouseleaveSpy;
+                }
+              }
+            }
+          }));
+
+          customCreatePad.open(task);
+
+          const entry = domQuery('.baz', customCreatePad.getHtml());
+
+          const child = document.createElement('span');
+
+          entry.appendChild(child);
+
+          // when moving between elements inside the same entry
+          mouseover(entry, child);
+
+          clock.tick(500);
+
+          mouseout(entry, child);
+
+          // then
+          expect(mouseenterSpy).not.to.have.been.called;
+          expect(mouseleaveSpy).not.to.have.been.called;
         }));
 
       });
@@ -578,4 +694,16 @@ function createCustomCreatePad(options = {}) {
   CustomCreatePad.$inject = [ 'canvas', 'eventBus' ];
 
   return CustomCreatePad;
+}
+
+function dragstart(element) {
+  element.dispatchEvent(new DragEvent('dragstart', { bubbles: true }));
+}
+
+function mouseover(element, relatedTarget) {
+  element.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, relatedTarget }));
+}
+
+function mouseout(element, relatedTarget) {
+  element.dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget }));
 }


### PR DESCRIPTION
### Proposed Changes


Display append pad entry title as tooltip to be consistent with context pad.


https://github.com/user-attachments/assets/abccb615-459d-440d-9102-08b763a83324



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
