### PR TITLE
fix: fix overlays overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.10.1
+
+* `FIX`: fix overlays overlapping ([#89](https://github.com/camunda/improved-canvas/pull/89))
+
 ## 1.10.0
 
 * `FEAT`: surface unfinished flows with an append indicator that opens the append menu on hover, guiding users to complete the paths ([#83](https://github.com/camunda/improved-canvas/pull/83))

--- a/lib/common/contextPad/ImprovedContextPad.js
+++ b/lib/common/contextPad/ImprovedContextPad.js
@@ -127,7 +127,30 @@ ImprovedContextPad.prototype._getPosition = function(target) {
 
   // top bounds
   if (top < CONTEXT_PAD_VISIBLE_PADDING) {
-    top = targetBounds.bottom + margin - containerBounds.top;
+    let flipBottom = targetBounds.bottom;
+
+    const overlays = this._injector.get('overlays', false);
+
+    // do not cover overlays that hang below the element (e.g. the DMN input data
+    // type dropdown); place the pad below the lowest such overlay instead
+    if (overlays && !Array.isArray(target)) {
+      const padLeft = containerBounds.left + left;
+      const padRight = padLeft + contextPadBounds.width;
+
+      overlays.get({ element: target }).forEach(({ html }) => {
+        const overlayBounds = html.getBoundingClientRect();
+
+        const hangsBelow = overlayBounds.bottom > targetBounds.bottom;
+        const overlapsHorizontally = overlayBounds.left < padRight
+          && overlayBounds.right > padLeft;
+
+        if (hangsBelow && overlapsHorizontally) {
+          flipBottom = Math.max(flipBottom, overlayBounds.bottom);
+        }
+      });
+    }
+
+    top = flipBottom + margin - containerBounds.top;
   }
 
   if (top < CONTEXT_PAD_VISIBLE_PADDING) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,9 +1706,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1723,9 +1720,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1740,9 +1734,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1757,9 +1748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1774,9 +1762,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1791,9 +1776,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1808,9 +1790,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1825,9 +1804,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1842,9 +1818,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1859,9 +1832,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1876,9 +1846,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1893,9 +1860,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1910,9 +1874,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2285,9 +2246,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2302,9 +2260,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2319,9 +2274,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2336,9 +2288,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2353,9 +2302,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2370,9 +2316,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2387,9 +2330,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2404,9 +2344,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2421,9 +2358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2438,9 +2372,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "bpmn-js-properties-panel": "^5.60.0",
         "camunda-bpmn-js-behaviors": "^1.18.0",
         "cross-env": "^10.1.0",
-        "dmn-js": "^17.8.1",
+        "dmn-js": "^17.9.0",
         "dmn-js-properties-panel": "^3.11.1",
         "downloadjs": "^1.4.7",
         "eslint": "^9.39.4",
@@ -4069,9 +4069,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.18.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.18.0.tgz",
-      "integrity": "sha512-aOVeXrjQc1ki0jlrSuwXDoye5nKO6uAtXCtmgQopUvF/aC9aJwoaBOsNvQ2Na9GmMc6X2b3xAefhRChvGgcbgQ==",
+      "version": "15.22.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.22.0.tgz",
+      "integrity": "sha512-xcX1e4lmRCrpwlnNqNHVqY8Xp4i70tXUZwO39IzRJsXWq6F+/osNs4biehnb5ZlHIzjZcEHWzOx/vlIui4qS8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4079,7 +4079,7 @@
         "clsx": "^2.1.1",
         "didi": "^11.0.0",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "object-refs": "^0.4.0",
         "path-intersection": "^4.1.0",
@@ -4141,29 +4141,29 @@
       }
     },
     "node_modules/dmn-js": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-17.8.1.tgz",
-      "integrity": "sha512-fGWZdorwZnRkKCwbcnpDY9K+pfxD2FiK3LTm8P8uQrkvVoeBv3rIMIw0SxQaVGPjwGVLrWEslOVdwME1rzBL9g==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js/-/dmn-js-17.9.0.tgz",
+      "integrity": "sha512-TM+DirsMbyuk+/WoPvqgqCFZ513u+RZmlMpwSxbvnJbXjGnRt52LwOX3IMzjfofMPln+VZuyo7Cy8zLPWE+x9g==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "dmn-js-boxed-expression": "^17.8.1",
-        "dmn-js-decision-table": "^17.8.1",
-        "dmn-js-drd": "^17.8.1",
-        "dmn-js-literal-expression": "^17.8.1",
-        "dmn-js-shared": "^17.8.1"
+        "dmn-js-boxed-expression": "^17.9.0",
+        "dmn-js-decision-table": "^17.9.0",
+        "dmn-js-drd": "^17.9.0",
+        "dmn-js-literal-expression": "^17.9.0",
+        "dmn-js-shared": "^17.9.0"
       }
     },
     "node_modules/dmn-js-boxed-expression": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-boxed-expression/-/dmn-js-boxed-expression-17.8.1.tgz",
-      "integrity": "sha512-v4hkE9tI6aAjHY6UKA8jLut3StKxkijNiuQea6Bbh1IYO/wNo6ObX+P8FdNPVPXea0kfwhx9F0XvFOxzz6u05Q==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js-boxed-expression/-/dmn-js-boxed-expression-17.9.0.tgz",
+      "integrity": "sha512-YJav0pxsm7F/PrhksT1LjD+1tqdCnMwKF8b01+AoKDJc9Q1tytpOePGdfaeqp9omr9GhFWgvuj9/Tkjcc2iHWw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/dmn-variable-resolver": "^0.7.0",
-        "diagram-js": "^15.13.0",
-        "dmn-js-shared": "^17.8.1",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.9.0",
         "inferno": "~5.6.3",
         "min-dash": "^5.0.0",
         "min-dom": "^5.3.0",
@@ -4171,16 +4171,16 @@
       }
     },
     "node_modules/dmn-js-decision-table": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-17.8.1.tgz",
-      "integrity": "sha512-n7jlNeEq/vYiQ2npb4Tnyqu6mVYqiS4VEz281NJWpei2cVC0RqpjZih7nM1YmAyoIwHZs4mAEV5/kuK4QkW0fA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js-decision-table/-/dmn-js-decision-table-17.9.0.tgz",
+      "integrity": "sha512-7msHl7joooYTfndTyPwqVQrNrtt1n2CMdh0nRBEUEL7RBQ4XVrixzv25iWA1Srs73iU8PCc1w4eHWEoIwBC/9w==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/dmn-variable-resolver": "^0.7.0",
         "css.escape": "^1.5.1",
-        "diagram-js": "^15.13.0",
-        "dmn-js-shared": "^17.8.1",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.9.0",
         "escape-html": "^1.0.3",
         "inferno": "~5.6.3",
         "min-dash": "^5.0.0",
@@ -4190,15 +4190,15 @@
       }
     },
     "node_modules/dmn-js-drd": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-17.8.1.tgz",
-      "integrity": "sha512-celWA3jQQQwKELiP9TPXxocjyYEW3lxYqyitZT/uVH2abZ5Nw30lAafIe+OgfqsS3qzTXGqQ/oW5ITkVrKFwGQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js-drd/-/dmn-js-drd-17.9.0.tgz",
+      "integrity": "sha512-l9Y0mazqTJYhNFun3GJjhj6++us82xV3vJwNVv2HheZLwjuR7lupeNhvKn/ZGcutDOX8Em45xEgZAlJL5Ilckg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "diagram-js": "^15.13.0",
-        "diagram-js-direct-editing": "^3.3.0",
-        "dmn-js-shared": "^17.8.1",
+        "diagram-js": "^15.21.0",
+        "diagram-js-direct-editing": "^3.4.0",
+        "dmn-js-shared": "^17.9.0",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^5.0.0",
@@ -4208,15 +4208,15 @@
       }
     },
     "node_modules/dmn-js-literal-expression": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-17.8.1.tgz",
-      "integrity": "sha512-8iYfxtSNXaL5doDXAs+2On2XVGHqJ+W8eFh3jEDLYEvucCyoqg7wiLRhhzMVYtGF34olD60FNOZuUoLBDgcZ+A==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js-literal-expression/-/dmn-js-literal-expression-17.9.0.tgz",
+      "integrity": "sha512-WQ5hbLErjhYzL28RVV5bBvJw+tn4YntOGoeNFK2Fa/28PL74A6G8WZ0iS0m1nXzIweaYeJrEKtXVTyz3zig5Yw==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@bpmn-io/dmn-variable-resolver": "^0.7.0",
-        "diagram-js": "^15.13.0",
-        "dmn-js-shared": "^17.8.1",
+        "diagram-js": "^15.21.0",
+        "dmn-js-shared": "^17.9.0",
         "escape-html": "^1.0.3",
         "inferno": "~5.6.3",
         "min-dash": "^5.0.0",
@@ -4244,14 +4244,14 @@
       }
     },
     "node_modules/dmn-js-shared": {
-      "version": "17.8.1",
-      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-17.8.1.tgz",
-      "integrity": "sha512-9OjNaXzJUo3NFl+eROnCu46A1aiKajaG3QFvkbnRpdsDgYMu4SPYabB6B9MomWFsfY3BunlwZJ+Czi8QtdKsrA==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/dmn-js-shared/-/dmn-js-shared-17.9.0.tgz",
+      "integrity": "sha512-cMVNaJcDGqjCq5Af9f95zWchYnrrHsslo298lApQtsSd8LPxOblhYm43/MsL7YVs9CZ/AiYgcTqY8gMWIjlWKg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@bpmn-io/feel-editor": "^2.5.2",
-        "diagram-js": "^15.13.0",
+        "@bpmn-io/feel-editor": "^2.6.0",
+        "diagram-js": "^15.21.0",
         "didi": "^11.0.0",
         "dmn-moddle": "^12.0.1",
         "ids": "^3.0.2",
@@ -7191,9 +7191,9 @@
       }
     },
     "node_modules/min-dash": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.0.0.tgz",
-      "integrity": "sha512-EGuoBnVL7/Fnv2sqakpX5WGmZehZ3YMmLayT7sM8E9DRU74kkeyMg4Rik1lsOkR2GbFNeBca4/L+UfU6gF0Edw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/min-dash/-/min-dash-5.1.0.tgz",
+      "integrity": "sha512-HAvN6XzmCQj+js43G9sJRRw8kj/7DvoxN7qhoIN9Xo5ZN1NMljtpyKs/NunXmw0QSWwlgZzNv6tLeEa4xaZ0tg==",
       "license": "MIT"
     },
     "node_modules/min-dom": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bpmn-js-properties-panel": "^5.60.0",
     "camunda-bpmn-js-behaviors": "^1.18.0",
     "cross-env": "^10.1.0",
-    "dmn-js": "^17.8.1",
+    "dmn-js": "^17.9.0",
     "dmn-js-properties-panel": "^3.11.1",
     "downloadjs": "^1.4.7",
     "eslint": "^9.39.4",

--- a/test/fixtures/input-data.dmn
+++ b/test/fixtures/input-data.dmn
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" id="Definitions_input_data" name="DRD" namespace="http://camunda.org/schema/1.0/dmn">
+  <inputData id="InputData_1" name="Input Data 1">
+    <variable id="InformationItem_1" name="Input Data 1" typeRef="string" />
+  </inputData>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNShape dmnElementRef="InputData_1">
+        <dc:Bounds height="45" width="125" x="160" y="10" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/test/spec/dmn/contextPad/ImprovedContextPad.spec.js
+++ b/test/spec/dmn/contextPad/ImprovedContextPad.spec.js
@@ -8,12 +8,14 @@ import {
 } from 'test/DMNTestHelper';
 
 import {
+  query as domQuery,
   queryAll as domQueryAll
 } from 'min-dom';
 
 import ImprovedContextPad from 'lib/dmn/contextPad';
 
 import diagramXML from 'test/fixtures/simple.dmn';
+import inputDataXML from 'test/fixtures/input-data.dmn';
 
 insertCoreStyles();
 insertDmnStyles();
@@ -21,37 +23,92 @@ insertDmnStyles();
 
 describe('<DMNImprovedContextPad>', function() {
 
-  beforeEach(bootstrapModeler(diagramXML, {
-    drd: {
-      additionalModules: [
-        ImprovedContextPad
-      ]
-    }
-  }));
+  describe('entries', function() {
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      drd: {
+        additionalModules: [
+          ImprovedContextPad
+        ]
+      }
+    }));
 
 
-  it('entries', inject(function(canvas, elementRegistry, contextPad) {
+    it('entries', inject(function(canvas, elementRegistry, contextPad) {
 
-    // given
-    const shape = elementRegistry.get('Decision_1');
+      // given
+      const shape = elementRegistry.get('Decision_1');
 
-    // when
-    contextPad.open(shape);
+      // when
+      contextPad.open(shape);
 
-    // then
-    const entries = [ ...domQueryAll('.djs-context-pad .entry', canvas.getContainer()) ];
+      // then
+      const entries = [ ...domQueryAll('.djs-context-pad .entry', canvas.getContainer()) ];
 
-    expect(entries.length).to.equal(8);
-    expect(entries.map(entry => entry.getAttribute('data-action'))).to.eql([
-      'replace',
-      'connect',
-      'append.decision',
-      'append.knowledge-source',
-      'append.business-knowledge-model',
-      'append.input-data',
-      'append.text-annotation',
-      'delete'
-    ]);
-  }));
+      expect(entries.length).to.equal(8);
+      expect(entries.map(entry => entry.getAttribute('data-action'))).to.eql([
+        'replace',
+        'connect',
+        'append.decision',
+        'append.knowledge-source',
+        'append.business-knowledge-model',
+        'append.input-data',
+        'append.text-annotation',
+        'delete'
+      ]);
+    }));
+
+  });
+
+
+  describe('position', function() {
+
+    beforeEach(bootstrapModeler(inputDataXML, {
+      drd: {
+        additionalModules: [
+          ImprovedContextPad
+        ]
+      }
+    }));
+
+
+    it('should not cover the type dropdown when flipped below', inject(
+      function(canvas, elementRegistry, selection, overlays) {
+
+        // given
+        const shape = elementRegistry.get('InputData_1');
+        const containerBounds = canvas.getContainer().getBoundingClientRect();
+
+        // place the element at the top of the container so the pad flips below
+        canvas.viewbox({
+          x: shape.x - 10,
+          y: shape.y - 2,
+          width: containerBounds.width,
+          height: containerBounds.height
+        });
+
+        // when
+        selection.select(shape);
+
+        // then
+        return whenScheduled().then(() => {
+          const [ dropdown ] = overlays.get({ element: shape, type: 'type-ref-dropdown' });
+          const contextPadHtml = domQuery('.djs-context-pad', canvas.getContainer());
+
+          const dropdownBottom = dropdown.html.getBoundingClientRect().bottom;
+          const contextPadTop = contextPadHtml.getBoundingClientRect().top;
+
+          expect(contextPadTop).to.be.at.least(dropdownBottom);
+        });
+      }
+    ));
+
+  });
 
 });
+
+
+// context pad position is updated asynchronously via the scheduler (setTimeout)
+function whenScheduled() {
+  return new Promise(resolve => setTimeout(resolve, 100));
+}

--- a/test/spec/dmn/contextPad/ImprovedContextPad.spec.js
+++ b/test/spec/dmn/contextPad/ImprovedContextPad.spec.js
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { useFakeTimers } from 'sinon';
 
 import {
   insertCoreStyles,
@@ -63,6 +64,8 @@ describe('<DMNImprovedContextPad>', function() {
 
   describe('position', function() {
 
+    let clock;
+
     beforeEach(bootstrapModeler(inputDataXML, {
       drd: {
         additionalModules: [
@@ -70,6 +73,14 @@ describe('<DMNImprovedContextPad>', function() {
         ]
       }
     }));
+
+    beforeEach(function() {
+      clock = useFakeTimers();
+    });
+
+    afterEach(function() {
+      clock.restore();
+    });
 
 
     it('should not cover the type dropdown when flipped below', inject(
@@ -90,16 +101,16 @@ describe('<DMNImprovedContextPad>', function() {
         // when
         selection.select(shape);
 
+        clock.tick(100);
+
         // then
-        return whenScheduled().then(() => {
-          const [ dropdown ] = overlays.get({ element: shape, type: 'type-ref-dropdown' });
-          const contextPadHtml = domQuery('.djs-context-pad', canvas.getContainer());
+        const [ dropdown ] = overlays.get({ element: shape, type: 'type-ref-dropdown' });
+        const contextPadHtml = domQuery('.djs-context-pad', canvas.getContainer());
 
-          const dropdownBottom = dropdown.html.getBoundingClientRect().bottom;
-          const contextPadTop = contextPadHtml.getBoundingClientRect().top;
+        const dropdownBottom = dropdown.html.getBoundingClientRect().bottom;
+        const contextPadTop = contextPadHtml.getBoundingClientRect().top;
 
-          expect(contextPadTop).to.be.at.least(dropdownBottom);
-        });
+        expect(contextPadTop).to.be.at.least(dropdownBottom);
       }
     ));
 
@@ -107,8 +118,3 @@ describe('<DMNImprovedContextPad>', function() {
 
 });
 
-
-// context pad position is updated asynchronously via the scheduler (setTimeout)
-function whenScheduled() {
-  return new Promise(resolve => setTimeout(resolve, 100));
-}


### PR DESCRIPTION



### Proposed Changes

This PR makes sure that the context pad does not overlap any overlays below the element, including subprocess drill down and input data dropdown.

chore: update to dmn-js@17.9.0

<img width="414" height="210" alt="Screenshot 2026-07-16 at 12 24 11" src="https://github.com/user-attachments/assets/a10929a4-6f45-41bc-afac-d9738542d20c" />
<img width="193" height="187" alt="Screenshot 2026-07-16 at 12 24 19" src="https://github.com/user-attachments/assets/adef2e14-e026-4331-82fa-3bb689a4faa5" />
<!--
Add relevant context (issue fixed or related to), a visual example
(screenshots or short videos) of UI/UX changes if any, and steps to try out your
changes. 
-->

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
