### PR TITLE
fix: append pad/indicator positioning after diagram-js outline changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+* `FIX`: correct misplaced append indicator on element's left edge ([#90](https://github.com/camunda/improved-canvas/pull/90))
+
+
 ## 1.10.1
 
 * `FIX`: fix overlays overlapping ([#89](https://github.com/camunda/improved-canvas/pull/89))

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -5,7 +5,7 @@ import CreatePad from '../../common/createPad/CreatePad';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-import { PAD_GAP } from '../../common/constants';
+import { PAD_GAP, OUTLINE_OFFSET } from '../../common/constants';
 
 // leading pad entries, in this order; any other entries follow in natural order.
 // connect is relocated here from the context pad.
@@ -98,15 +98,13 @@ export default class AppendCreatePad extends CreatePad {
   }
 
   getPosition(target) {
-    const containerBounds = this._canvas.getContainer().getBoundingClientRect();
+    const { x, y, width, height } = this._canvas.getAbsoluteBBox(target);
 
-    const targetBounds = this._canvas.getGraphics(target).getBoundingClientRect();
-
-    const gap = PAD_GAP * this._canvas.zoom();
+    const gap = (PAD_GAP + OUTLINE_OFFSET) * this._canvas.zoom();
 
     return {
-      left: targetBounds.right - containerBounds.left + gap,
-      top: targetBounds.top - containerBounds.top + targetBounds.height / 2
+      left: x + width + gap,
+      top: y + height / 2
     };
   }
 

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -11,6 +11,10 @@ const OVERLAY_TYPE = 'append-indicator';
 // so we need to add this to the gap so the indicator's "+" lines up with the pad's "+"
 const PAD_ICON_PADDING = 4;
 
+// mirrors diagram-js' outline offset (Outline#_outlineOffset),
+// keeps the indicator just outside the element's selection outline
+const OUTLINE_OFFSET = 5;
+
 // below this zoom the indicator is hidden instead of shrinking further
 const MIN_SCALE = 0.3;
 
@@ -22,15 +26,15 @@ const CLOSE_DELAY_MS = 300;
  * sequence flow. Hovering it opens the append menu.
  */
 export default class AppendIndicator {
-  constructor(appendCreatePad, elementRegistry, eventBus, outline, overlays, selection, translate) {
+  constructor(appendCreatePad, elementRegistry, eventBus, overlays, selection, translate) {
     this._appendCreatePad = appendCreatePad;
     this._elementRegistry = elementRegistry;
     this._overlays = overlays;
     this._selection = selection;
     this._translate = translate;
 
-    // indicator gap from the element, calculated by common pad gap + element outline offset + append pad padding to the '+' icon
-    this._indicatorGap = PAD_GAP + outline.offset + PAD_ICON_PADDING;
+    // indicator gap from the element: common pad gap + outline offset + append pad padding to the '+' icon
+    this._indicatorGap = PAD_GAP + OUTLINE_OFFSET + PAD_ICON_PADDING;
 
     this._closeTimeout = null;
 
@@ -261,7 +265,6 @@ AppendIndicator.$inject = [
   'appendCreatePad',
   'elementRegistry',
   'eventBus',
-  'outline',
   'overlays',
   'selection',
   'translate'

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -3,17 +3,13 @@ import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
-import { PAD_GAP } from '../../common/constants';
+import { PAD_GAP, OUTLINE_OFFSET } from '../../common/constants';
 
 const OVERLAY_TYPE = 'append-indicator';
 
 // the append pad's "+" button has padding inside the pad box (its CSS padding);
 // so we need to add this to the gap so the indicator's "+" lines up with the pad's "+"
 const PAD_ICON_PADDING = 4;
-
-// mirrors diagram-js' outline offset (Outline#_outlineOffset),
-// keeps the indicator just outside the element's selection outline
-const OUTLINE_OFFSET = 5;
 
 // below this zoom the indicator is hidden instead of shrinking further
 const MIN_SCALE = 0.3;

--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -2,3 +2,7 @@
 // Shared by the append pad, append indicator, and context pad so they keep a
 // consistent distance from the element.
 export const PAD_GAP = 5;
+
+// mirrors diagram-js' outline offset (Outline#_outlineOffset),
+// floating pads sit just outside the element's selection outline.
+export const OUTLINE_OFFSET = 5;

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -13,7 +13,7 @@ import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
 
 import AppendCreatePad from 'lib/bpmn/appendCreatePad';
 
-import { PAD_GAP } from 'lib/common/constants';
+import { PAD_GAP, OUTLINE_OFFSET } from 'lib/common/constants';
 
 import AppendCanvasLockModule from 'lib/bpmn/appendCanvasLock';
 
@@ -113,6 +113,30 @@ describe('<AppendCreatePad>', function() {
     // then
     expect(canvas.getContainer().querySelector('.djs-append-create-pad')).to.exist;
   }));
+
+
+  it('should position the pad independent of the lazily created outline', inject(
+    function(appendCreatePad, selection, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when opening before the element was ever selected (no outline yet)
+      appendCreatePad.open(task);
+
+      const before = appendCreatePad.getHtml().style.left;
+
+      // and when opening after selection created the outline
+      selection.select(task);
+
+      appendCreatePad.open(task);
+
+      const after = appendCreatePad.getHtml().style.left;
+
+      // then the pad does not jump
+      expect(after).to.eql(before);
+    }
+  ));
 
 
   it('should open append popup on icon click', inject(
@@ -409,7 +433,9 @@ describe('<AppendCreatePad>', function() {
 
         const gap = appendCreatePad.getPosition(task).left - (targetBounds.right - containerBounds.left);
 
-        expect(gap).to.be.closeTo(PAD_GAP * 0.8, 1);
+        // the pad sits beyond the element's outline; the element gfx has no outline
+        // here (never hovered/selected), so the gap spans the outline offset too
+        expect(gap).to.be.closeTo((PAD_GAP + OUTLINE_OFFSET) * 0.8, 1);
       }
     ));
 

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -94,6 +94,21 @@ describe('<AppendIndicator>', function() {
   ));
 
 
+  it('should position the indicator past the element right edge', inject(
+    function(overlays, elementRegistry) {
+
+      // given
+      const element = elementRegistry.get('Task_NoOutgoing');
+
+      // when
+      const [ overlay ] = overlays.get({ element, type: 'append-indicator' });
+
+      // then it sits outside the element
+      expect(overlay.position.left).to.be.above(element.width);
+    }
+  ));
+
+
   it('should not scale the indicator larger than default when zooming in', inject(
     function(canvas) {
 


### PR DESCRIPTION
### Proposed Changes

Fixes two append-UI positioning bugs from the latest `diagram-js` bump. `diagram-js` 15.19.0 reworked the element outline — it made the offset [private](https://github.com/bpmn-io/diagram-js/commit/231ccd3f67e256f290cb992f2793087e5f1cca6c) (`Outline#offset` -> `Outline#_outlineOffset`) and started [rendering it lazily](https://github.com/bpmn-io/diagram-js/commit/f84ed76a55479e70c4dc924b7e2c470aad605efc).

- **Issue 1: Indicator pinned to the left edge:** `outline.offset` became `undefined`, so the gap was `NaN`. Fixed by using an `OUTLINE_OFFSET` constant and dropping the `outline` dependency.
- **Issue 2: Pad jumps on open:** it was positioned from the DOM box, which grows when the lazy outline appears(after element select). Fixed by positioning from `canvas.getAbsoluteBBox` (model-derived) instead.

As alternative for the issue 1, we could also concider to restore public `Outline#offset` in `diagram-js` and drop the constant.


**Before**:


https://github.com/user-attachments/assets/bba84aad-4f1c-4002-8515-aa5cc3e7195f

**After**:

https://github.com/user-attachments/assets/a6e10cc1-213a-4b69-b508-57f10d5ff767



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
