### PR TITLE
fix: increase pad gap to not overlap element resize handles

### DIFF
--- a/lib/common/constants.js
+++ b/lib/common/constants.js
@@ -1,7 +1,7 @@
 // gap between an element and a floating pad, in diagram units; scales with zoom.
 // Shared by the append pad, append indicator, and context pad so they keep a
 // consistent distance from the element.
-export const PAD_GAP = 5;
+export const PAD_GAP = 7;
 
 // mirrors diagram-js' outline offset (Outline#_outlineOffset),
 // floating pads sit just outside the element's selection outline.


### PR DESCRIPTION
### Proposed Changes

Increase pad gap(5px -> 7px) to not overlap element resize handles

Before:
<img width="722" height="371" alt="image" src="https://github.com/user-attachments/assets/2cc1fde2-41c2-41f4-8c78-0b38b1b3f43e" />


After:

<img width="1090" height="492" alt="image" src="https://github.com/user-attachments/assets/cf9d8aaf-d52b-48e9-a521-f9fea2e76c2c" />


### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
