### PR TITLE
fix: allow overriding append popup width via css variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 ___Note:__ Yet to be released changes appear here._
 
 * `FIX`: correct misplaced append indicator on element's left edge ([#90](https://github.com/camunda/improved-canvas/pull/90))
-
+* `FIX`: allow overriding append popup width via css variable ([#94](https://github.com/camunda/improved-canvas/pull/94))
 
 ## 1.10.1
 

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -90,7 +90,7 @@ export default class AppendCreatePad extends CreatePad {
             target,
             'bpmn-append',
             { x: left, y: top },
-            { title, width: 300, search: true }
+            { title, width: 'var(--bpmn-append-popup-width, 300px)', search: true }
           );
         }
       }

--- a/lib/bpmn/appendCreatePad/AppendEditorActions.js
+++ b/lib/bpmn/appendCreatePad/AppendEditorActions.js
@@ -50,7 +50,7 @@ export default class AppendEditorActions {
             y: bBox.top
           }, {
             title: this._translate('Append element'),
-            width: 300,
+            width: 'var(--bpmn-append-popup-width, 300px)',
             search: true
           });
         } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "axe-core": "^4.11.1",
         "babel-loader": "^10.0.0",
         "babel-plugin-istanbul": "^7.0.1",
-        "bpmn-js": "^18.21.0",
+        "bpmn-js": "^18.22.0",
         "bpmn-js-color-picker": "^0.7.2",
         "bpmn-js-create-append-anything": "^1.3.1",
         "bpmn-js-element-templates": "^2.27.0",
@@ -3143,18 +3143,18 @@
       "dev": true
     },
     "node_modules/bpmn-js": {
-      "version": "18.21.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.21.0.tgz",
-      "integrity": "sha512-TVPsgsTnD24jrcZ5bjU3LAfhEp4UtfnRIQ53Spf7Cs2nMofFU27uZ/Z5MTxNzfB5PVczjZbx7UTRmq+RcCZ7HA==",
+      "version": "18.22.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-18.22.0.tgz",
+      "integrity": "sha512-hM5aOiyLVdVGA80nveJLXFVQMpsaST7RilErjeKfXMhpZQJTnzU+yLDaenIJsq2f90+9inyktVPqsS1Ersik2A==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "bpmn-moddle": "^10.0.0",
-        "diagram-js": "^15.20.0",
-        "diagram-js-direct-editing": "^3.4.0",
+        "diagram-js": "^15.23.0",
+        "diagram-js-direct-editing": "^3.5.1",
         "ids": "^3.0.2",
         "inherits-browser": "^0.1.0",
-        "min-dash": "^5.0.0",
+        "min-dash": "^5.1.0",
         "min-dom": "^5.3.0",
         "tiny-svg": "^4.1.4"
       },
@@ -4000,9 +4000,9 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "15.22.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.22.0.tgz",
-      "integrity": "sha512-xcX1e4lmRCrpwlnNqNHVqY8Xp4i70tXUZwO39IzRJsXWq6F+/osNs4biehnb5ZlHIzjZcEHWzOx/vlIui4qS8w==",
+      "version": "15.23.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-15.23.0.tgz",
+      "integrity": "sha512-cCgL+4Ep0xrLe6TtdvRVgo6bWYjUbrQg+ES/9rpltqmTD2YaPoC+NYcRsKYw/fDO+1RN0q16NzErP1svVZhNQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4021,14 +4021,14 @@
       }
     },
     "node_modules/diagram-js-direct-editing": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.4.0.tgz",
-      "integrity": "sha512-eXfd+nxJr5xt3YlCrs+E53mPi+gqBWRBkAXkR99ZPL7Pl0B3H5nkv/uiwx4Q4vJU/Sp8Jy3zVdhP/Y2c6loTjw==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.5.1.tgz",
+      "integrity": "sha512-fEQCQ/x5oKVV0m7Nmgv7i85Vhw+kJkKNXF8zcV5Vm0KwF8x/8e3Ax0aJgdXt8/fDPymEkY8HmZweXIipCeeh+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "min-dash": "^5.0.0",
-        "min-dom": "^5.2.0"
+        "min-dom": "^5.3.0"
       },
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "axe-core": "^4.11.1",
     "babel-loader": "^10.0.0",
     "babel-plugin-istanbul": "^7.0.1",
-    "bpmn-js": "^18.21.0",
+    "bpmn-js": "^18.22.0",
     "bpmn-js-color-picker": "^0.7.2",
     "bpmn-js-create-append-anything": "^1.3.1",
     "bpmn-js-element-templates": "^2.27.0",

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -11,6 +11,8 @@ import {
 
 import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
 
+import { query as domQuery } from 'min-dom';
+
 import AppendCreatePad from 'lib/bpmn/appendCreatePad';
 
 import { PAD_GAP, OUTLINE_OFFSET } from 'lib/common/constants';
@@ -158,6 +160,25 @@ describe('<AppendCreatePad>', function() {
       expect(open).to.have.been.calledOnce;
       expect(open.firstCall.args[ 0 ]).to.equal(task);
       expect(open.firstCall.args[ 1 ]).to.equal('bpmn-append');
+    }
+  ));
+
+
+  it('should open append popup at default width', inject(
+    function(appendCreatePad, canvas, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      appendCreatePad.open(task);
+
+      const icon = canvas.getContainer().querySelector('.djs-append-create-pad .djs-create-pad-entry-cta');
+
+      // when
+      icon.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+      // then
+      expect(getComputedStyle(domQuery('.djs-popup')).width).to.eql('300px');
     }
   ));
 


### PR DESCRIPTION
### Proposed Changes

Allow overriding append popup width via css variable

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
