### PR TITLE
fix: show append/context pads and append indicator during label editing

### DIFF
--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -18,27 +18,13 @@ const PAD_ENTRIES_ORDER = [
 ];
 
 export default class AppendCreatePad extends CreatePad {
-  constructor(canvas, contextPadProvider, eventBus, popupMenu, rules, selection, translate) {
+  constructor(canvas, contextPadProvider, eventBus, popupMenu, rules, translate) {
     super(canvas, eventBus, 'djs-append-create-pad');
 
     this._contextPadProvider = contextPadProvider;
     this._popupMenu = popupMenu;
     this._rules = rules;
-    this._selection = selection;
     this._translate = translate;
-
-    // direct editing is a dedicated mode where the user's context is the edit box,
-    // so step aside for its duration and reopen afterwards if its element is still
-    // the single selected one
-    eventBus.on('directEditing.activate', () => this.close());
-
-    eventBus.on('directEditing.deactivate', () => {
-      const selection = this._selection.get();
-
-      if (selection.length === 1) {
-        this.open(selection[0]);
-      }
-    });
   }
 
   canOpen(target) {
@@ -131,6 +117,5 @@ AppendCreatePad.$inject = [
   'eventBus',
   'popupMenu',
   'rules',
-  'selection',
   'translate'
 ];

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -35,7 +35,7 @@ export default class AppendIndicator {
     this._closeTimeout = null;
 
     // reasons the indicators are disabled; they are visible when there are none
-    // (e.g. while dragging, direct editing or disabled externally by a lock)
+    // (e.g. while dragging or disabled externally by a lock)
     this._disabledBy = new Set();
 
     // refresh all indicators on load
@@ -67,11 +67,9 @@ export default class AppendIndicator {
       this._setVisible(target, true);
     });
 
-    // hide indicators during a drag or direct edit, then restore them
+    // hide indicators during a drag, then restore them
     eventBus.on('drag.start', () => this._setDisabledBy('dragging', true));
     eventBus.on('drag.cleanup', () => this._setDisabledBy('dragging', false));
-    eventBus.on('directEditing.activate', () => this._setDisabledBy('editing', true));
-    eventBus.on('directEditing.deactivate', () => this._setDisabledBy('editing', false));
   }
 
   _canAdd(element) {

--- a/lib/common/contextPad/ImprovedContextPad.js
+++ b/lib/common/contextPad/ImprovedContextPad.js
@@ -30,8 +30,6 @@ export default function ImprovedContextPad(canvas, contextPad, eventBus, injecto
   this._contextPad = contextPad;
   this._injector = injector;
 
-  this._editing = false;
-
   contextPad._getPosition = this._getPosition.bind(this);
   contextPad._updateVisibility = this._updateVisibility.bind(this);
 
@@ -40,29 +38,10 @@ export default function ImprovedContextPad(canvas, contextPad, eventBus, injecto
   eventBus.on('canvas.viewbox.changed', () => {
     this._updateVisibility();
   });
-
-  // direct editing is a dedicated mode where the user's context is the edit box,
-  // so keep the context pad out of the way for its duration and bring it back
-  // once editing completes or is cancelled
-  eventBus.on('directEditing.activate', () => {
-    this._editing = true;
-    this._contextPad.hide();
-  });
-
-  eventBus.on('directEditing.deactivate', () => {
-    this._editing = false;
-    this._updateVisibility();
-  });
 }
 
 ImprovedContextPad.prototype._updateVisibility = function() {
   if (!this._contextPad.isOpen()) {
-    return;
-  }
-
-  if (this._editing) {
-    this._contextPad.hide();
-
     return;
   }
 

--- a/lib/common/createPad/CreatePad.js
+++ b/lib/common/createPad/CreatePad.js
@@ -72,7 +72,7 @@ export default class CreatePad {
       const { target } = this._current;
 
       if (elements.includes(target)) {
-        this.open(target);
+        this._refresh(target);
       }
     });
 
@@ -100,6 +100,23 @@ export default class CreatePad {
     }
 
     this._open(target);
+  }
+
+  /**
+   * Reposition the open pad for its changed target, or close it if the target
+   * can no longer be opened.
+   *
+   * @param {Element} target
+   */
+  _refresh(target) {
+    if (!this.canOpen(target)) {
+      this.close();
+
+      return;
+    }
+
+    this._updatePosition();
+    this._updateVisibility();
   }
 
   show() {

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -11,6 +11,8 @@ import {
 
 import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
 
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
 import { query as domQuery } from 'min-dom';
 
 import AppendCreatePad from 'lib/bpmn/appendCreatePad';
@@ -480,6 +482,32 @@ describe('<AppendCreatePad>', function() {
 
         // then it remains visible so the append affordance is preserved
         expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+
+    it('should append a task after a label edit commits mid-click', inject(
+      function(appendCreatePad, canvas, elementRegistry, eventBus) {
+
+        // given the append pad is open
+        const task = elementRegistry.get('Task_1');
+
+        appendCreatePad.open(task);
+
+        const appendTask = canvas.getContainer().querySelector(
+          '.djs-append-create-pad [data-entry-id="append.append-task"]'
+        );
+
+        const tasksBefore = elementRegistry.filter(element => is(element, 'bpmn:Task')).length;
+
+        // when a label edit commits on blur (fires elements.changed for the target)
+        // while the append task button is clicked
+        eventBus.fire('elements.changed', { elements: [ task ] });
+
+        appendTask.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+        // then a new task is appended to the diagram
+        expect(elementRegistry.filter(element => is(element, 'bpmn:Task')).length).to.equal(tasksBefore + 1);
       }
     ));
 

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -465,7 +465,7 @@ describe('<AppendCreatePad>', function() {
 
   describe('label editing', function() {
 
-    it('should close while label editing is active', inject(
+    it('should stay open while label editing is active', inject(
       function(appendCreatePad, directEditing, elementRegistry, selection) {
 
         // given the pad is open for a selected element
@@ -478,28 +478,7 @@ describe('<AppendCreatePad>', function() {
         // when direct editing starts
         directEditing.activate(task);
 
-        // then
-        expect(appendCreatePad.isOpen()).to.be.false;
-      }
-    ));
-
-
-    it('should reopen for the same element when label editing ends', inject(
-      function(appendCreatePad, directEditing, elementRegistry, selection) {
-
-        // given direct editing was active for a selected element
-        const task = elementRegistry.get('Task_1');
-
-        selection.select(task);
-
-        directEditing.activate(task);
-
-        expect(appendCreatePad.isOpen()).to.be.false;
-
-        // when direct editing ends
-        directEditing.cancel();
-
-        // then
+        // then it remains visible so the append affordance is preserved
         expect(appendCreatePad.isOpen()).to.be.true;
       }
     ));

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -307,7 +307,7 @@ describe('<AppendIndicator>', function() {
   ));
 
 
-  it('should hide indicators while a label is edited and restore them afterwards', inject(
+  it('should keep indicators visible while a label is edited', inject(
     function(canvas, directEditing, elementRegistry) {
 
       // given
@@ -316,34 +316,7 @@ describe('<AppendIndicator>', function() {
       // when a label is edited directly
       directEditing.activate(task);
 
-      // then the indicator is hidden so it does not overlap the edit box
-      expect(getIndicator('Task_NoOutgoing', canvas).style.display).to.equal('none');
-
-      // when editing ends
-      directEditing.cancel();
-
-      // then it is restored
-      expect(getIndicator('Task_NoOutgoing', canvas).style.display).not.to.equal('none');
-    }
-  ));
-
-  it('should keep indicators hidden when a drag-append hands over to editing', inject(
-    function(canvas, directEditing, elementRegistry, eventBus) {
-
-      // given a drag-append: editing activates before the drag is cleaned up
-      const task = elementRegistry.get('Task_NoOutgoing');
-
-      eventBus.fire('drag.start', {});
-      directEditing.activate(task);
-      eventBus.fire('drag.cleanup', {});
-
-      // then indicators stay hidden while editing continues
-      expect(getIndicator('Task_NoOutgoing', canvas).style.display).to.equal('none');
-
-      // when editing ends
-      directEditing.cancel();
-
-      // then they are restored
+      // then the indicator stays visible so users keep their append affordance
       expect(getIndicator('Task_NoOutgoing', canvas).style.display).not.to.equal('none');
     }
   ));

--- a/test/spec/bpmn/contextPad/ImprovedContextPad.spec.js
+++ b/test/spec/bpmn/contextPad/ImprovedContextPad.spec.js
@@ -130,7 +130,7 @@ describe('<ImprovedContextPad>', function() {
 
   describe('label editing', function() {
 
-    it('should hide the context pad while label editing is active', inject(
+    it('should keep the context pad visible while label editing is active', inject(
       function(contextPad, directEditing, elementRegistry) {
 
         // given
@@ -143,28 +143,7 @@ describe('<ImprovedContextPad>', function() {
         // when
         directEditing.activate(element);
 
-        // then
-        expect(contextPad.isShown()).to.be.false;
-      }
-    ));
-
-
-    it('should restore the context pad when label editing ends', inject(
-      function(contextPad, directEditing, elementRegistry) {
-
-        // given
-        const element = elementRegistry.get('Task_1');
-
-        contextPad.open(element);
-
-        directEditing.activate(element);
-
-        expect(contextPad.isShown()).to.be.false;
-
-        // when
-        directEditing.cancel();
-
-        // then
+        // then it stays visible
         expect(contextPad.isShown()).to.be.true;
       }
     ));

--- a/test/spec/common/createPad/CreatePad.spec.js
+++ b/test/spec/common/createPad/CreatePad.spec.js
@@ -221,12 +221,14 @@ describe('<CreatePad>', function() {
     }));
 
 
-    it('should re-open on elements changed (target changed)', inject(function(customCreatePad, elementRegistry, eventBus, selection) {
+    it('should reposition in place on elements changed (target changed)', inject(function(customCreatePad, elementRegistry, eventBus, selection) {
 
       // given
       const task = elementRegistry.get('Task_1');
 
       selection.select(task);
+
+      const htmlBefore = customCreatePad.getHtml();
 
       const openSpy = spy(customCreatePad, 'open'),
             closeSpy = spy(customCreatePad, 'close');
@@ -238,10 +240,35 @@ describe('<CreatePad>', function() {
         ]
       });
 
-      // then
-      expect(closeSpy).to.have.been.called;
-      expect(openSpy).to.have.been.called;
+      // then it is refreshed in place, not re-created
+      expect(closeSpy).not.to.have.been.called;
+      expect(openSpy).not.to.have.been.called;
       expect(customCreatePad.isOpen()).to.be.true;
+      expect(customCreatePad.getHtml()).to.equal(htmlBefore);
+    }));
+
+
+    it('should close on elements changed when the target can no longer be opened', inject(function(customCreatePad, elementRegistry, eventBus, selection) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      selection.select(task);
+
+      expect(customCreatePad.isOpen()).to.be.true;
+
+      // the target can no longer be opened
+      stub(customCreatePad, 'canOpen').returns(false);
+
+      // when
+      eventBus.fire('elements.changed', {
+        elements: [
+          task
+        ]
+      });
+
+      // then
+      expect(customCreatePad.isOpen()).to.be.false;
     }));
 
 


### PR DESCRIPTION
### Proposed Changes

Show append/context pads and append indicator during label editing

This reverts the previous [change](https://github.com/camunda/improved-canvas/pull/83/changes/e3ceadfc2ce52cb6d9e4c489223ac51ea129227e) where we hide them during label editing. Since the append pad has been moved from the bottom to the right side of the element, the pads no longer overlap the label on boundary events.


https://github.com/user-attachments/assets/8a84fb64-ae53-456c-980b-cb938fa36eb6



### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [x] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
