### PR TITLE
fix: open create/append/replace menus with the popup width variable

### DIFF
--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -7,6 +7,8 @@ import icons from '../../common/contextPad/ContextPadIcons';
 
 import { PAD_GAP, OUTLINE_OFFSET } from '../../common/constants';
 
+import { popupWidth } from '../../util';
+
 // leading pad entries, in this order; any other entries follow in natural order.
 // connect is relocated here from the context pad.
 const PAD_ENTRIES_ORDER = [
@@ -76,7 +78,7 @@ export default class AppendCreatePad extends CreatePad {
             target,
             'bpmn-append',
             { x: left, y: top },
-            { title, width: 'var(--bpmn-append-popup-width, 300px)', search: true }
+            { title, width: popupWidth('bpmn-append'), search: true }
           );
         }
       }

--- a/lib/bpmn/appendCreatePad/AppendEditorActions.js
+++ b/lib/bpmn/appendCreatePad/AppendEditorActions.js
@@ -1,3 +1,5 @@
+import { popupWidth } from '../../util';
+
 /**
  * Registers and executes append editor action.
  */
@@ -50,7 +52,7 @@ export default class AppendEditorActions {
             y: bBox.top
           }, {
             title: this._translate('Append element'),
-            width: 'var(--bpmn-append-popup-width, 300px)',
+            width: popupWidth('bpmn-append'),
             search: true
           });
         } else {

--- a/lib/bpmn/contextPad/ImprovedContextPadProvider.js
+++ b/lib/bpmn/contextPad/ImprovedContextPadProvider.js
@@ -11,6 +11,8 @@ import {
   updateIcon
 } from '../../common/contextPad/ImprovedContextPadProvider';
 
+import { popupWidth } from '../../util';
+
 const VERY_LOW_PRIORITY = 100;
 
 export default function BPMNImprovedContextPadProvider(canvas, contextPad, eventBus, popupMenu) {
@@ -150,7 +152,7 @@ BPMNImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function
         }
       });
 
-      this._popupMenu.open(target, menuId, position);
+      this._popupMenu.open(target, menuId, position, { width: popupWidth(menuId) });
     }
   };
 };

--- a/lib/common/contextPad/ImprovedContextPadProvider.js
+++ b/lib/common/contextPad/ImprovedContextPadProvider.js
@@ -9,6 +9,8 @@ import {
   omit
 } from 'min-dash';
 
+import { popupWidth } from '../../util';
+
 const VERY_LOW_PRIORITY = 100;
 
 export default function ImprovedContextPadProvider(canvas, contextPad, eventBus, popupMenu) {
@@ -88,7 +90,7 @@ ImprovedContextPadProvider.prototype._updatePopupMenuOpenPosition = function(ent
         }
       });
 
-      this._popupMenu.open(target, menuId, position);
+      this._popupMenu.open(target, menuId, position, { width: popupWidth(menuId) });
     }
   };
 };

--- a/lib/util.js
+++ b/lib/util.js
@@ -18,3 +18,9 @@ export function insertCSS(name, css) {
 
   head.appendChild(style);
 }
+
+// popup menu width as a CSS custom property, so a specific menu can be widened
+// by defining `--<menuId>-popup-width` (defaults to 300px)
+export function popupWidth(menuId) {
+  return `var(--${ menuId }-popup-width, 300px)`;
+}


### PR DESCRIPTION
### Proposed Changes

Open the create/append/replace popup menus with their width expressed as a CSS
custom property — `var(--<menuId>-popup-width, 300px)` — via a small shared
helper.

Previously the context-pad menus (e.g. **change**) were opened with **no width**,
so they were pinned by the base `.djs-popup { max-width: 300px }` and a
`--bpmn-<menu>-popup-width` override had no effect; the append/create pad
duplicated the variable string inline.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [ ] Pull request __establishes context__
  * [ ] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [ ] __Steps to try out__, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)

<!--

Thanks for creating this pull request! ❤️

-->
