### PR TITLE
Show append indicator instead of full pad when selection has outgoing flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@camunda/improved-canvas](https://github.com/camunda/imp
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.11.0
+
+* `FEAT`: show the append indicator instead of the full pad when the selected element has an outgoing sequence flow, highlighting it as a call to action ([#99](https://github.com/camunda/improved-canvas/pull/99))
+
 ## 1.10.4
 
 * `DEPS`: update to `bpmn-js-create-append-anything@2.0.0`

--- a/assets/create-pad.css
+++ b/assets/create-pad.css
@@ -124,6 +124,17 @@
   }
 }
 
+/* the selected element's indicator stands in for the pad's "+" call to action,
+   so it takes that look; unselected ones stay subtle in a crowded diagram */
+.bio-improved-canvas .djs-append-indicator.selected {
+  background-color: var(--context-pad-entry-call-to-action-background-color);
+  color: var(--context-pad-entry-call-to-action-color);
+
+  &:hover {
+    background-color: var(--context-pad-entry-call-to-action-hover-background-color);
+  }
+}
+
 .bio-improved-canvas .djs-create-pad .djs-create-pad-tooltip {
   display: contents;
 }

--- a/lib/bpmn/appendCanvasLock/AppendCanvasLock.js
+++ b/lib/bpmn/appendCanvasLock/AppendCanvasLock.js
@@ -52,10 +52,10 @@ export default function AppendCanvasLock(eventBus, injector) {
       return;
     }
 
-    // reopen the pad for a single selection once unlocked
+    // reopen the pad for a single selection once unlocked, if it would auto-open anyway
     const selected = selection && selection.get();
 
-    if (selected && selected.length === 1) {
+    if (selected && selected.length === 1 && appendCreatePad.canAutoOpen(selected[0])) {
       appendCreatePad.open(selected[0]);
     }
   });

--- a/lib/bpmn/appendCreatePad/AppendCreatePad.js
+++ b/lib/bpmn/appendCreatePad/AppendCreatePad.js
@@ -7,6 +7,8 @@ import icons from '../../common/contextPad/ContextPadIcons';
 
 import { PAD_GAP, OUTLINE_OFFSET } from '../../common/constants';
 
+import { allowsAppendIndicator, hasOutgoingSequenceFlow } from '../util';
+
 // leading pad entries, in this order; any other entries follow in natural order.
 // connect is relocated here from the context pad.
 const PAD_ENTRIES_ORDER = [
@@ -44,6 +46,22 @@ export default class AppendCreatePad extends CreatePad {
 
   canAppend(target) {
     return this._rules.allowed('shape.append', { element: target });
+  }
+
+  // whether the append indicator (a "+" revealed on hover) can stand in for the
+  // pad on the target; the indicator and #canAutoOpen must agree on this, so
+  // both ask here
+  canShowAppendIndicator(target) {
+    return allowsAppendIndicator(target) && this.canAppend(target);
+  }
+
+  // a target that already has an outgoing sequence flow is instead offered
+  // the append indicator, not the full pad - unless no indicator can stand in
+  // for it, in which case the pad keeps opening, or there'd be no way to
+  // append or connect at all
+  canAutoOpen(target) {
+    return this.canOpen(target)
+      && !(hasOutgoingSequenceFlow(target) && this.canShowAppendIndicator(target));
   }
 
   getEntries(target) {

--- a/lib/bpmn/appendCreatePad/AppendEditorActions.js
+++ b/lib/bpmn/appendCreatePad/AppendEditorActions.js
@@ -40,22 +40,41 @@ export default class AppendEditorActions {
       appendCreatePad: (event) => {
         const selected = this._selection.get();
 
-        if (appendCreatePad.isOpen() && appendCreatePad.canAppend(selected[ 0 ])) {
-          const html = appendCreatePad.getHtml();
+        const target = selected.length === 1 ? selected[ 0 ] : null;
 
-          const bBox = html.getBoundingClientRect();
-
-          this._popupMenu.open(selected[ 0 ], 'bpmn-append', {
-            x: bBox.left,
-            y: bBox.top
-          }, {
-            title: this._translate('Append element'),
-            width: 'var(--bpmn-append-popup-width, 300px)',
-            search: true
-          });
-        } else {
+        if (!target || !appendCreatePad.canAppend(target)) {
           this._palette.triggerEntry('create', 'click', event);
+
+          return;
         }
+
+        // the pad anchors the popup, so make sure it is open
+        appendCreatePad.open(target);
+
+        const html = appendCreatePad.getHtml();
+
+        // opening was vetoed, e.g. while the canvas is locked; do not fall back
+        // to the palette either, creating elements is not allowed then
+        if (!html) {
+          return;
+        }
+
+        const { left, top } = html.getBoundingClientRect();
+
+        // leave no pad behind the popup for a target that only ever shows its
+        // indicator; closing it in the same tick keeps it from ever showing
+        if (!appendCreatePad.canAutoOpen(target)) {
+          appendCreatePad.close();
+        }
+
+        this._popupMenu.open(target, 'bpmn-append', {
+          x: left,
+          y: top
+        }, {
+          title: this._translate('Append element'),
+          width: 'var(--bpmn-append-popup-width, 300px)',
+          search: true
+        });
       }
     });
   }

--- a/lib/bpmn/appendIndicator/AppendIndicator.js
+++ b/lib/bpmn/appendIndicator/AppendIndicator.js
@@ -1,9 +1,10 @@
 import { isConnection } from 'diagram-js/lib/util/ModelUtil';
-import { is } from 'bpmn-js/lib/util/ModelUtil';
 
 import icons from '../../common/contextPad/ContextPadIcons';
 
 import { PAD_GAP, OUTLINE_OFFSET } from '../../common/constants';
+
+import { hasOutgoingSequenceFlow } from '../util';
 
 const OVERLAY_TYPE = 'append-indicator';
 
@@ -19,7 +20,12 @@ const CLOSE_DELAY_MS = 300;
 
 /**
  * Shows a grey "+" next to every appendable element that has no outgoing
- * sequence flow. Hovering it opens the append menu.
+ * sequence flow, as well as next to the selected element even if it has one
+ * (replacing the full append pad, which only auto-opens for elements without
+ * an outgoing sequence flow). Hovering it opens the append menu.
+ *
+ * The selected element's "+" is highlighted as a call to action, the others
+ * stay subtle so they do not overwhelm a crowded diagram.
  */
 export default class AppendIndicator {
   constructor(appendCreatePad, elementRegistry, eventBus, overlays, selection, translate) {
@@ -34,6 +40,10 @@ export default class AppendIndicator {
 
     this._closeTimeout = null;
 
+    // the sole selected element, if any; it gets an indicator even with an
+    // outgoing sequence flow, since its full pad no longer auto-opens
+    this._selected = null;
+
     // reasons the indicators are disabled; they are visible when there are none
     // (e.g. while dragging or disabled externally by a lock)
     this._disabledBy = new Set();
@@ -43,6 +53,16 @@ export default class AppendIndicator {
 
     // refresh indicators for changed elements
     eventBus.on('elements.changed', ({ elements }) => this._refreshChanged(elements));
+
+    // track the sole selection, refreshing both the previous and new target
+    eventBus.on('selection.changed', ({ newSelection }) => {
+      const previous = this._selected;
+
+      this._selected = newSelection.length === 1 ? newSelection[ 0 ] : null;
+
+      this._refresh(previous);
+      this._refresh(this._selected);
+    });
 
     // a connection's source and target aren't always in elements.changed;
     // refresh both ends from the command context
@@ -73,10 +93,8 @@ export default class AppendIndicator {
   }
 
   _canAdd(element) {
-    return element.parent // exclude the root
-      && !is(element.parent, 'bpmn:AdHocSubProcess') // order is free in ad-hoc, no path to complete
-      && this._appendCreatePad.canAppend(element)
-      && !hasOutgoingSequenceFlow(element);
+    return this._appendCreatePad.canShowAppendIndicator(element)
+      && (!hasOutgoingSequenceFlow(element) || element === this._selected);
   }
 
   _add(element, position) {
@@ -88,6 +106,12 @@ export default class AppendIndicator {
     html.innerHTML = icons.createElement;
 
     html.addEventListener('mouseenter', () => this._openMenu(element));
+
+    this._setSelected(html, element === this._selected);
+
+    if (this._isDisabled()) {
+      html.style.display = 'none';
+    }
 
     this._overlays.add(element, OVERLAY_TYPE, {
       position,
@@ -143,10 +167,12 @@ export default class AppendIndicator {
 
     const position = this._getPosition(element);
 
-    // already in the right place, nothing to do
+    // already in the right place, only the highlight may need to catch up
     if (existing
         && existing.position.left === position.left
         && existing.position.top === position.top) {
+      this._setSelected(existing.html, element === this._selected);
+
       return;
     }
 
@@ -201,6 +227,11 @@ export default class AppendIndicator {
     this._setOverlaysVisibility(this._overlays.get({ type: OVERLAY_TYPE }), visible);
   }
 
+  // highlight the selected element's indicator as a call to action
+  _setSelected(html, selected) {
+    html.classList.toggle('selected', selected);
+  }
+
   _setOverlaysVisibility(overlays, visible) {
     overlays.forEach(overlay => {
       overlay.html.style.display = visible ? '' : 'none';
@@ -229,11 +260,12 @@ export default class AppendIndicator {
     this._closeTimeout = setTimeout(() => this._closeOrRestoreSelection(), CLOSE_DELAY_MS);
   }
 
-  // reopen the selected element's pad instead of leaving none open
+  // reopen the selected element's pad instead of leaving none open, unless
+  // that element only ever shows its indicator (e.g. it has outgoing flow)
   _closeOrRestoreSelection() {
     const selection = this._selection.get();
 
-    if (selection.length === 1) {
+    if (selection.length === 1 && this._appendCreatePad.canAutoOpen(selection[0])) {
       this._appendCreatePad.open(selection[0]);
     } else {
       this._appendCreatePad.close();
@@ -247,12 +279,6 @@ export default class AppendIndicator {
       this._closeTimeout = null;
     }
   }
-}
-
-function hasOutgoingSequenceFlow(element) {
-  return element.outgoing && element.outgoing.some(
-    connection => is(connection, 'bpmn:SequenceFlow')
-  );
 }
 
 AppendIndicator.$inject = [

--- a/lib/bpmn/util.js
+++ b/lib/bpmn/util.js
@@ -1,0 +1,14 @@
+import { is } from 'bpmn-js/lib/util/ModelUtil';
+
+export function hasOutgoingSequenceFlow(element) {
+  return !!element.outgoing && element.outgoing.some(
+    connection => is(connection, 'bpmn:SequenceFlow')
+  );
+}
+
+// whether an element's place in the diagram allows an append indicator at all;
+// never the root, and never inside an ad-hoc sub-process, where order is free
+// and there is no path to complete
+export function allowsAppendIndicator(element) {
+  return !!element.parent && !is(element.parent, 'bpmn:AdHocSubProcess');
+}

--- a/lib/common/createPad/CreatePad.js
+++ b/lib/common/createPad/CreatePad.js
@@ -61,7 +61,11 @@ export default class CreatePad {
 
       const target = newSelection[ 0 ];
 
-      this.open(target);
+      if (this.canAutoOpen(target)) {
+        this.open(target);
+      } else if (this.isOpen()) {
+        this.close();
+      }
     });
 
     eventBus.on('elements.changed', ({ elements }) => {
@@ -176,6 +180,19 @@ export default class CreatePad {
    */
   canOpen(target) {
     throw new Error('must implement canOpen');
+  }
+
+  /**
+   * Check whether the pad should open automatically when the target becomes
+   * the sole selection. May be overridden by sub classes; defaults to
+   * whatever {@link #canOpen} allows.
+   *
+   * @param {Element} target
+   *
+   * @returns {boolean}
+   */
+  canAutoOpen(target) {
+    return this.canOpen(target);
   }
 
   isOpen() {

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.bpmn
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.bpmn
@@ -37,6 +37,15 @@
     <association id="Association_1" associationDirection="One" sourceRef="CompensationBoundaryEvent_1" targetRef="CompensationTask_1" />
     <textAnnotation id="TextAnnotation_1" />
     <association id="Association_2" associationDirection="None" sourceRef="ReceiveTask_1" targetRef="TextAnnotation_1" />
+    <adHocSubProcess id="AdHocSubProcess_1">
+      <task id="Task_InAdHoc_1">
+        <outgoing>SequenceFlow_AdHoc</outgoing>
+      </task>
+      <task id="Task_InAdHoc_2">
+        <incoming>SequenceFlow_AdHoc</incoming>
+      </task>
+      <sequenceFlow id="SequenceFlow_AdHoc" sourceRef="Task_InAdHoc_1" targetRef="Task_InAdHoc_2" />
+    </adHocSubProcess>
   </process>
   <bpmndi:BPMNDiagram id="BpmnDiagram_1">
     <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
@@ -99,6 +108,19 @@
       <bpmndi:BPMNEdge id="Association_0h1iobe_di" bpmnElement="Association_2">
         <di:waypoint x="588" y="160" />
         <di:waypoint x="636" y="110" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="AdHocSubProcess_1_di" bpmnElement="AdHocSubProcess_1" isExpanded="true">
+        <omgdc:Bounds x="152" y="400" width="350" height="200" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InAdHoc_1_di" bpmnElement="Task_InAdHoc_1">
+        <omgdc:Bounds x="192" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_InAdHoc_2_di" bpmnElement="Task_InAdHoc_2">
+        <omgdc:Bounds x="352" y="460" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_AdHoc_di" bpmnElement="SequenceFlow_AdHoc">
+        <di:waypoint x="292" y="500" />
+        <di:waypoint x="352" y="500" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
+++ b/test/spec/bpmn/appendCreatePad/AppendCreatePad.spec.js
@@ -88,7 +88,7 @@ describe('<AppendCreatePad>', function() {
       function(appendCreatePad, canvasLock, elementRegistry, selection) {
 
         // given
-        selection.select(elementRegistry.get('Task_1'));
+        selection.select(elementRegistry.get('EndEvent_1'));
 
         canvasLock.lock();
 
@@ -100,6 +100,23 @@ describe('<AppendCreatePad>', function() {
 
         // then
         expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+
+    it('should not reopen the pad for a selection with outgoing flow after unlock', inject(
+      function(appendCreatePad, canvasLock, elementRegistry, selection) {
+
+        // given
+        selection.select(elementRegistry.get('Task_1'));
+
+        canvasLock.lock();
+
+        // when
+        canvasLock.unlock();
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
       }
     ));
 
@@ -228,6 +245,120 @@ describe('<AppendCreatePad>', function() {
   });
 
 
+  describe('#canAutoOpen', function() {
+
+    it('should return true for an element without outgoing sequence flow', inject(function(appendCreatePad, elementRegistry) {
+
+      // given
+      const endEvent = elementRegistry.get('EndEvent_1');
+
+      // when
+      const canAutoOpen = appendCreatePad.canAutoOpen(endEvent);
+
+      // then
+      expect(canAutoOpen).to.be.true;
+    }));
+
+
+    it('should return false for an element with outgoing sequence flow', inject(function(appendCreatePad, elementRegistry) {
+
+      // given
+      const task = elementRegistry.get('Task_1');
+
+      // when
+      const canAutoOpen = appendCreatePad.canAutoOpen(task);
+
+      // then
+      expect(canAutoOpen).to.be.false;
+    }));
+
+
+    it('should return true for an element with outgoing sequence flow inside an ad-hoc sub-process', inject(
+      function(appendCreatePad, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_InAdHoc_1');
+
+        // when
+        const canAutoOpen = appendCreatePad.canAutoOpen(task);
+
+        // then
+        expect(canAutoOpen).to.be.true;
+      }
+    ));
+
+  });
+
+
+  describe('auto-open on selection', function() {
+
+    it('should open automatically when selecting an element without outgoing flow', inject(
+      function(appendCreatePad, elementRegistry, selection) {
+
+        // given
+        const endEvent = elementRegistry.get('EndEvent_1');
+
+        // when
+        selection.select(endEvent);
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+
+    it('should not open automatically when selecting an element with outgoing flow', inject(
+      function(appendCreatePad, elementRegistry, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        selection.select(task);
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+
+    it('should still open on direct call for an element with outgoing flow', inject(
+      function(appendCreatePad, elementRegistry) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        // when
+        appendCreatePad.open(task);
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+
+    it('should close when selecting an element with outgoing flow after another was open', inject(
+      function(appendCreatePad, elementRegistry, selection) {
+
+        // given
+        const endEvent = elementRegistry.get('EndEvent_1');
+        const task = elementRegistry.get('Task_1');
+
+        selection.select(endEvent);
+
+        expect(appendCreatePad.isOpen()).to.be.true;
+
+        // when
+        selection.select(task);
+
+        // then
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+  });
+
+
   describe('#canAppend', function() {
 
     it('should return true if append allowed', inject(function(appendCreatePad, elementRegistry) {
@@ -345,6 +476,54 @@ describe('<AppendCreatePad>', function() {
         expect(triggerEntry.firstCall.args[ 0 ]).to.equal('create');
         expect(triggerEntry.firstCall.args[ 1 ]).to.equal('click');
         expect(open.getCalls().filter(({ args }) => args[ 1 ] === 'bpmn-append')).to.have.length(0);
+      }
+    ));
+
+
+    it('should trigger the append popup for a selected element with outgoing flow', inject(
+      function(appendCreatePad, editorActions, elementRegistry, popupMenu, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        const open = spy(popupMenu, 'open');
+
+        selection.select(task);
+
+        expect(appendCreatePad.isOpen()).to.be.false;
+
+        // when
+        editorActions.trigger('appendCreatePad', {});
+
+        // then
+        expect(open).to.have.been.calledOnce;
+        expect(open.firstCall.args[ 0 ]).to.equal(task);
+        expect(open.firstCall.args[ 1 ]).to.equal('bpmn-append');
+
+        // and
+        expect(appendCreatePad.isOpen()).to.be.false;
+      }
+    ));
+
+
+    it('should not throw when opening the pad is vetoed', inject(
+      function(appendCreatePad, editorActions, elementRegistry, eventBus, popupMenu, selection) {
+
+        // given
+        const task = elementRegistry.get('Task_1');
+
+        selection.select(task);
+
+        eventBus.once('createPad.open.allowed', () => false);
+
+        const open = spy(popupMenu, 'open');
+
+        // when
+        expect(() => editorActions.trigger('appendCreatePad', {})).not.to.throw();
+
+        // then
+        expect(open).not.to.have.been.called;
+        expect(appendCreatePad.isOpen()).to.be.false;
       }
     ));
 
@@ -471,14 +650,16 @@ describe('<AppendCreatePad>', function() {
       function(appendCreatePad, directEditing, elementRegistry, selection) {
 
         // given the pad is open for a selected element
-        const task = elementRegistry.get('Task_1');
+        const boundaryEvent = elementRegistry.get('BoundaryEvent_1');
 
-        selection.select(task);
+        selection.select(boundaryEvent);
 
         expect(appendCreatePad.isOpen()).to.be.true;
 
         // when direct editing starts
-        directEditing.activate(task);
+        directEditing.activate(boundaryEvent);
+
+        expect(directEditing.isActive()).to.be.true;
 
         // then it remains visible so the append affordance is preserved
         expect(appendCreatePad.isOpen()).to.be.true;

--- a/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
+++ b/test/spec/bpmn/appendIndicator/AppendIndicator.spec.js
@@ -13,6 +13,8 @@ import { query as domQuery } from 'min-dom';
 
 import CanvasLockModule from '@bpmn-io/diagram-js-canvas-lock';
 
+import RuleProvider from 'diagram-js/lib/features/rules/RuleProvider';
+
 import AppendIndicator from 'lib/bpmn/appendIndicator';
 
 import AppendCanvasLockModule from 'lib/bpmn/appendCanvasLock';
@@ -77,6 +79,135 @@ describe('<AppendIndicator>', function() {
 
       // then appending is not allowed after a compensation activity
       expect(getIndicator('Task_Compensation', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should show indicator for the selected element even with outgoing flow', inject(
+    function(canvas, elementRegistry, selection) {
+
+      // when
+      selection.select(elementRegistry.get('Task_WithOutgoing'));
+
+      // then
+      expect(getIndicator('Task_WithOutgoing', canvas)).to.exist;
+    }
+  ));
+
+
+  it('should hide the indicator again once deselected', inject(
+    function(canvas, elementRegistry, selection) {
+
+      // given
+      selection.select(elementRegistry.get('Task_WithOutgoing'));
+
+      // when
+      selection.select(null);
+
+      // then
+      expect(getIndicator('Task_WithOutgoing', canvas)).not.to.exist;
+    }
+  ));
+
+
+  it('should highlight the selected element\'s indicator', inject(
+    function(canvas, elementRegistry, selection) {
+
+      // when
+      selection.select(elementRegistry.get('Task_WithOutgoing'));
+
+      // then
+      expect(getIndicator('Task_WithOutgoing', canvas).classList.contains('selected')).to.be.true;
+      expect(getIndicator('Task_NoOutgoing', canvas).classList.contains('selected')).to.be.false;
+    }
+  ));
+
+
+  it('should highlight the selected element\'s existing indicator', inject(
+    function(canvas, elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('Task_NoOutgoing');
+
+      expect(getIndicator('Task_NoOutgoing', canvas).classList.contains('selected')).to.be.false;
+
+      // when
+      selection.select(element);
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas).classList.contains('selected')).to.be.true;
+    }
+  ));
+
+
+  it('should drop the highlight once deselected', inject(
+    function(canvas, elementRegistry, selection) {
+
+      // given
+      const element = elementRegistry.get('Task_NoOutgoing');
+
+      selection.select(element);
+
+      // when
+      selection.select(null);
+
+      // then
+      expect(getIndicator('Task_NoOutgoing', canvas).classList.contains('selected')).to.be.false;
+    }
+  ));
+
+
+  it('should open the append menu on hover for the selected element with outgoing flow', inject(
+    function(appendCreatePad, canvas, elementRegistry, selection) {
+
+      // given
+      selection.select(elementRegistry.get('Task_WithOutgoing'));
+
+      const open = spy(appendCreatePad, 'open');
+
+      const indicator = getIndicator('Task_WithOutgoing', canvas);
+
+      // when
+      indicator.dispatchEvent(new MouseEvent('mouseenter'));
+
+      // then
+      expect(open).to.have.been.calledWith(elementRegistry.get('Task_WithOutgoing'));
+    }
+  ));
+
+
+  it('should not auto-open the full pad for a selected element with outgoing flow', inject(
+    function(appendCreatePad, elementRegistry, selection) {
+
+      // when
+      selection.select(elementRegistry.get('Task_WithOutgoing'));
+
+      // then
+      expect(appendCreatePad.isOpen()).to.be.false;
+    }
+  ));
+
+
+  it('should always offer either the pad or an indicator for a selected element', inject(
+    function(appendCreatePad, canvas, elementRegistry, selection) {
+
+      // given
+      const targets = elementRegistry.filter(
+        element => element.parent && !element.labelTarget && appendCreatePad.canOpen(element)
+      );
+
+      expect(targets).not.to.be.empty;
+
+      targets.forEach(element => {
+
+        // when
+        selection.select(element);
+
+        // then
+        const offered = appendCreatePad.isOpen() || !!getIndicator(element.id, canvas);
+
+        expect(offered, `no pad and no indicator for <${element.id}>`).to.be.true;
+      });
     }
   ));
 
@@ -443,5 +574,50 @@ describe('<AppendIndicator>', function() {
       expect(getIndicator('Task_NoOutgoing', canvas)).to.exist;
     }
   ));
+
+
+  describe('appending denied by a custom rule', function() {
+
+    class DenyAppendRules extends RuleProvider {
+      constructor(eventBus) {
+        super(eventBus);
+
+        this.addRule('shape.append', ({ element }) => {
+          if (element.id === 'Task_WithOutgoing') {
+            return false;
+          }
+        });
+      }
+    }
+
+    DenyAppendRules.$inject = [ 'eventBus' ];
+
+    beforeEach(bootstrapModeler(diagramXML, {
+      additionalModules: [
+        AppendIndicator,
+        {
+          __init__: [ 'denyAppendRules' ],
+          denyAppendRules: [ 'type', DenyAppendRules ]
+        }
+      ]
+    }));
+
+
+    it('should open the pad instead, as no indicator can stand in', inject(
+      function(appendCreatePad, canvas, elementRegistry, selection) {
+
+        // given
+        const element = elementRegistry.get('Task_WithOutgoing');
+
+        // when
+        selection.select(element);
+
+        // then
+        expect(getIndicator('Task_WithOutgoing', canvas)).not.to.exist;
+        expect(appendCreatePad.isOpen()).to.be.true;
+      }
+    ));
+
+  });
 
 });


### PR DESCRIPTION


https://github.com/user-attachments/assets/275880c3-6f0e-4c78-844a-7316ae78fb0b



### Proposed Changes

Related to https://camunda.slack.com/archives/C0693F1NFK5/p1787225393604509

Selecting an element that already has an outgoing sequence flow no longer auto-opens the full append pad. Instead it shows the "+" append indicator (same one used for unselected elements without an outgoing flow), revealed on hover. Elements without an outgoing sequence flow keep the current behavior: the full pad still auto-opens on selection.

The selected element's "+" is highlighted as a call to action, standing in for the pad's own "+" that no longer auto-opens. Every other indicator stays subtle, so a crowded diagram does not light up — not all selection is done to fork, split or append.

Edge cases surfaced during implementation, all covered:
- Elements inside an ad-hoc sub-process never get the indicator (order is free there), so the pad still auto-opens for them even with an outgoing flow — otherwise selecting them would offer no append affordance at all.
- The same holds wherever appending is denied but connecting is not, e.g. through a downstream `shape.append` rule: no indicator can stand in, so the pad keeps auto-opening and `connect` stays reachable. `AppendCreatePad#canShowAppendIndicator` is the single predicate both the indicator and the pad's auto-open ask, so the two cannot drift apart.
- The `A` keyboard shortcut / editor action to open the append popup no longer depends on the pad already being open, so it still works for a selected element with an outgoing flow. The pad only anchors the popup there and closes again in the same tick, leaving nothing behind once the popup is dismissed.

### Checklist

Ensure you provide everything we need to review your contribution:

* [x] Contribution __meets our [definition of done](https://github.com/bpmn-io/.github/blob/main/resources/DEFINITION_OF_DONE.md)__
* [x] Pull request __establishes context__
  * [x] __Link to related issue(s)__, i.e. `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`
  * [x] __Brief textual description__ of the changes
  * [ ] __Screenshots or short videos__ showing UI/UX changes
  * [x] __Steps to try out__: select any task with an existing outgoing sequence flow — the full append pad no longer pops up immediately; the highlighted "+" appears next to it and opens the append menu on hover.

`npx @bpmn-io/sr camunda/improved-canvas#feature/append-indicator-when-selected-with-outgoing-flow`
